### PR TITLE
Support different shells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- [`#6`](https://github.com/Aloso/to-html/pull/6): Support different shells.
+
+  All shells can be used that have a `-c <command>` argument to execute a command, and support multiple commands separated with `;`. This includes `bash`, `fish`, `ksh` and `zsh`.
+
+- [`#5`](https://github.com/Aloso/to-html/pull/5): Add `--doc`/`-d` flag to emit a full HTML document. It can then be redirected to a file like this:
+
+    ```shell
+    $ to-html 'cargo test --workspace' -d > output.html
+    $ firefox output.html
+    ```
+
 ## [0.1.1]
 
 - [`#4`](https://github.com/Aloso/to-html/pull/4): FreeBSD support added (this also fixed a few bugs on macOS)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ dependencies = [
 
 [[package]]
 name = "fake-tty"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "fnv"
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "to-html"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "ansi-to-html",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "to-html"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Ludwig Stecher <ludwig.stecher@gmx.de>"]
 description = "Render a terminal with ANSI colors as HTML"
 categories = ["command-line-utilities"]
@@ -19,7 +19,7 @@ members = ["crates/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-fake-tty = { path = "./crates/fake-tty", version = "0.2" }
+fake-tty = { path = "./crates/fake-tty", version = "0.3" }
 ansi-to-html = { path = "./crates/ansi-to-html", version = "0.1" }
 clap = "2"
 dirs-next = "2"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # to-html
 
-Terminal wrapper for rendering a terminal on a website by converting ANSI escape sequences to HTML. Depends on [bash](https://www.gnu.org/software/bash/).
+Terminal wrapper for rendering a terminal on a website by converting ANSI escape sequences to HTML. Works with many shells, including bash, fish, ksh and zsh.
 
 [![Crates.io](https://img.shields.io/crates/l/to_html)](./LICENSE) [![Crates.io](https://img.shields.io/crates/v/to-html)](https://crates.io/crates/to-html) [![Tests](https://github.com/Aloso/to-html/workflows/Test/badge.svg)](https://github.com/Aloso/to-html/actions?query=workflow%3ATest)
 
@@ -12,7 +12,7 @@ The changelog can be found [here](CHANGELOG.md).
 
 How to install colo is explained on the [releases page](https://github.com/Aloso/to-html/releases).
 
-## Examples 📚
+## Usage 📚
 
 Execute a command:
 
@@ -26,12 +26,41 @@ Execute several commands:
 to-html 'echo "Hello "' 'echo world' ls
 ```
 
-Commands can contain bash syntax, including pipes and redirections:
-
+Commands can contain shell syntax, including pipes and redirections:
 
 ```bash
 to-html "echo Hello world! | grep 'H' > somefile.txt"
 ```
+
+The default shell is bash. Use `--shell`/`-s` to use a different shell:
+
+```bash
+to-html -sfish "../" "ls"   # executed with fish
+```
+
+By default, to-html emits a `<pre>` tag. Use `--doc`/`-d` to generate a whole HTML document (including CSS):
+
+```bash
+to-html -d "ls --color" > output.html
+```
+
+By default, to-html only displays an arrow (`>`) as prompt. To display the current working directory, pass `--cwd`/`-c`:
+
+```bash
+to-html -c "cd .." "ls"
+```
+
+Example output:
+
+<pre>
+~/Develop/to-html/crates $ cd ..
+~/Develop/to-html $ ls
+Cargo.lock  CHANGELOG.md  docs     README.md  target
+Cargo.toml  crates        LICENSE  src
+~/Develop/to-html $
+</pre>
+
+(colors can't be shown on GitHub)
 
 ## ANSI support 🎨
 

--- a/crates/fake-tty/Cargo.toml
+++ b/crates/fake-tty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fake-tty"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Ludwig Stecher <ludwig.stecher@gmx.de>"]
 description = "Run command with bash pretending to be a tty"
 categories = []


### PR DESCRIPTION
The shell can be specified with `--shell`/`-s`:

```bash
to-html -sfish 'ls'
```

Closes #2 