### PR TITLE
Revamp CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Print information
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,33 +10,28 @@ jobs:
   rustfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
           components: rustfmt
       - uses: actions/checkout@v2
       - name: Run `cargo fmt`
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: |
+          cargo fmt --all -- --check
 
   clippy:
     needs: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
           components: clippy
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run `cargo clippy`
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cargo clippy -- -D warnings
 
   build:
     needs: clippy
@@ -45,10 +40,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          override: true
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build and run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   push:
   pull_request:
+  schedule:
+    # Run monthly to keep Rust toolchain changes fresh
+    - cron: '0 0 1 * *'
 
 jobs:
   rustfmt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Run `cargo clippy`
         run: |
-          cargo clippy -- -D warnings
+          cargo clippy
 
   build:
     needs: clippy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   rustfmt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,13 @@ on:
 jobs:
   rustfmt:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        channel: [stable, beta]
     steps:
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.channel }}
           components: rustfmt
       - uses: actions/checkout@v3
       - name: Run `cargo fmt`
@@ -22,10 +25,13 @@ jobs:
   clippy:
     needs: rustfmt
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        channel: [stable, beta]
     steps:
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.channel }}
           components: clippy
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,11 +44,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        channel: [stable, beta]
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.channel }}
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build and run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run `cargo fmt`
         run: |
           cargo fmt --all -- --check
@@ -28,7 +28,7 @@ jobs:
           toolchain: stable
           components: clippy
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run `cargo clippy`
         run: |
           cargo clippy -- -D warnings
@@ -44,7 +44,7 @@ jobs:
         with:
           toolchain: stable
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build and run tests
         run: |
           cargo test --verbose --workspace


### PR DESCRIPTION
The commits should be pretty self-explanatory, but in short this:

- Switches away from `actions-rs` actions since they're no longer maintained and usually spit out deprecation notices
- Bumps `actions/checkout` to the latest version
- Runs CI against beta to preemptively find any possible regressions or deprecation warnings
- Runs jobs on all pushes and pull requests, so that PRs get CI runs
- Schedules a monthly CI run to catch any issues with the latest stable and beta early

Let me know if you have any questions (this CI run should fail due to the single clippy lint)