### PR TITLE
Add a config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "basic-toml"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,7 +85,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -218,7 +227,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -248,7 +257,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -329,6 +338,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +368,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d9531f94112cfc3e4c8f5f02cb2b58f72c97b7efd85f70203cc6d8efda5927"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -381,7 +421,7 @@ checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -389,10 +429,12 @@ name = "to-html"
 version = "0.1.3"
 dependencies = [
  "ansi-to-html",
+ "basic-toml",
  "clap",
  "dirs-next",
  "fake-tty",
  "logos",
+ "serde",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ clap = { version = "4.1.10", features = ["derive", "wrap_help"] }
 dirs-next = "2.0.0"
 logos = "0.12.1"
 thiserror = "1.0.33"
+serde = { version = "1.0.159", features = ["derive"] }
+basic-toml = "0.1.2"
 
 [profile.dev.package."*"]
 opt-level = 1

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -1,0 +1,23 @@
+[shell]
+# The shell to run commands under
+# CLI Arg: --shell
+# Default: "bash"
+program = "zsh"
+
+[output]
+# If the current working directory should be displayed in the shell prompt
+# CLI Arg: --cwd
+# Default: false
+cwd = true
+# Whether the output should generate a whole HTML document (including CSS)
+# CLI Arg: --doc
+# Default: false
+full_document = true
+# Commands to syntax highlight from the provided commands
+# CLI Arg: --highlight
+# Default: []
+highlight = ["cargo", "git"]
+# A custom prefix used for CSS classes
+# CLI Arg: --prefix
+# Default: Not set
+css_prefix = "custom"

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -1,0 +1,45 @@
+use clap::Parser;
+
+pub fn parse() -> Cli {
+    Cli::parse()
+}
+
+#[derive(Parser)]
+#[command(
+    author,
+    version,
+    about,
+    max_term_width = 100,
+    help_template = "\
+{before-help}{name} {version}
+{author-with-newline}{about-with-newline}
+{usage-heading} {usage}
+
+{all-args}{after-help}"
+)]
+pub struct Cli {
+    /// The command(s) to execute. Must be wrapped in quotes.
+    #[arg(required = true)]
+    pub commands: Vec<String>,
+    /// The shell to run the command in. On macOS and FreeBSD, the shell has to support
+    /// `-c <command>`
+    #[arg(short, long)]
+    pub shell: Option<String>,
+    /// Programs that have subcommands (which should be highlighted). Multiple arguments are
+    /// separated with a comma, e.g. `to-html -l git,cargo,npm "git checkout main"`
+    #[arg(short = 'l', long, value_delimiter = ',')]
+    pub highlight: Option<Vec<String>>,
+    /// Prefix for CSS classes. For example, with the `to-html` prefix, the `arg` class becomes
+    /// `to-html-arg`
+    #[arg(short, long)]
+    pub prefix: Option<String>,
+    /// Don't run the commands, just emit the HTML for the command prompt
+    #[arg(short, long)]
+    pub no_run: bool,
+    /// Print the (abbreviated) current working directory in the command prompt
+    #[arg(short, long)]
+    pub cwd: bool,
+    /// Output a complete HTML document, not just a `<pre>`
+    #[arg(short, long)]
+    pub doc: bool,
+}

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -1,0 +1,50 @@
+use std::{fs, io};
+
+use serde::Deserialize;
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("Failed detecting configuration directory")]
+    ConfigDetection,
+    #[error("I/O error while trying to read config file: {0}")]
+    Io(#[from] io::Error),
+    #[error("Config file has invalid format: {0}")]
+    Parsing(#[from] basic_toml::Error),
+}
+
+pub fn load() -> Result<Config, Error> {
+    let to_html_config = dirs_next::config_dir()
+        .ok_or(Error::ConfigDetection)?
+        .join("to-html")
+        .join("config.toml");
+
+    match fs::read_to_string(&to_html_config) {
+        Ok(contents) => match basic_toml::from_str(&contents) {
+            Ok(config) => Ok(config),
+            Err(e) => Err(e.into()),
+        },
+        Err(e) => match e.kind() {
+            io::ErrorKind::NotFound => Ok(Config::default()),
+            _ => Err(e.into()),
+        },
+    }
+}
+
+#[derive(Deserialize, Default)]
+pub struct Config {
+    pub shell: Shell,
+    pub output: Output,
+}
+
+#[derive(Deserialize, Default)]
+pub struct Shell {
+    pub program: Option<String>,
+}
+
+#[derive(Deserialize, Default)]
+pub struct Output {
+    pub cwd: bool,
+    pub full_document: bool,
+    pub highlight: Vec<String>,
+    pub css_prefix: Option<String>,
+}

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -1,0 +1,80 @@
+//! Handles all of the configuration for `to-html`
+//!
+//! `to-html` can be configured either through CLI flags or through a config file. Options passed
+//! on the command line take priority over those set in the config file when merging
+//!
+//! The flow is represented by `cli::Args` and `config::Config` being consolidated into the final
+//! `Opts` that is used through the rest of the application
+
+use std::path::PathBuf;
+
+use ansi_to_html::Esc;
+
+mod cli;
+mod config;
+
+#[derive(Debug)]
+pub struct Opts {
+    pub commands: Vec<String>,
+    pub shell: Option<String>,
+    pub highlight: Vec<String>,
+    pub prefix: String,
+    pub no_run: bool,
+    pub prompt: ShellPrompt,
+    pub doc: bool,
+}
+
+impl Opts {
+    pub fn load() -> Result<Self, crate::StdError> {
+        let config::Config {
+            shell: config::Shell {
+                program: config_shell,
+            },
+            output:
+                config::Output {
+                    cwd: config_cwd,
+                    full_document: config_doc,
+                    highlight: config_highlight,
+                    css_prefix: config_prefix,
+                },
+        } = config::load()?;
+
+        let cli::Cli {
+            commands: cli_commands,
+            shell: cli_shell,
+            highlight: cli_highlight,
+            prefix: cli_prefix,
+            no_run: cli_no_run,
+            cwd: cli_cwd,
+            doc: cli_doc,
+        } = cli::parse();
+
+        let prompt = if cli_cwd || config_cwd {
+            ShellPrompt::Cwd {
+                home: dirs_next::home_dir(),
+            }
+        } else {
+            ShellPrompt::Arrow
+        };
+        let prefix = cli_prefix
+            .or(config_prefix)
+            .map(|s| format!("{}-", Esc(s)))
+            .unwrap_or_default();
+
+        Ok(Self {
+            commands: cli_commands,
+            shell: cli_shell.or(config_shell),
+            highlight: cli_highlight.unwrap_or(config_highlight),
+            prefix,
+            no_run: cli_no_run,
+            prompt,
+            doc: cli_doc || config_doc,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum ShellPrompt {
+    Arrow,
+    Cwd { home: Option<PathBuf> },
+}


### PR DESCRIPTION
Resolves #16

Nothing really too crazy to mention. I opted for having separate a separate `Cli` and `Config` struct that gets consolidated into the final `Opts` used throughout the program, so that things work fine if distinct values are added to `Config` that aren't present in `Cli`

This pulls in `basic-toml` which is a library by dtolnay that aims to be a simpler alternative to the current `toml` crate