### PR TITLE
Generate shell completions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,8 @@ jobs:
         include:
           - os: ubuntu-latest
             platform: linux
-            file_ending: ""
           - os: macos-latest
             platform: macos
-            file_ending: ""
 
     steps:
       - name: Checkout
@@ -80,14 +78,14 @@ jobs:
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       - name: Build project
+        env:
+          SHELL_COMPLETIONS_DIR: completions
         run: cargo build --release --locked
 
       - name: Upload release assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: taiki-e/upload-rust-binary-action@v1
         with:
-          upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_name: to-html_${{ matrix.platform }}_${{ steps.vars.outputs.tag }}${{ matrix.file_ending }}
-          asset_path: target/release/to-html${{ matrix.file_ending }}
-          asset_content_type: application/octet-stream
+          bin: to-html
+          include: completions
+          asset_name: to-html_${{ matrix.platform }}_${{ steps.vars.outputs.tag }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04ddfaacc3bc9e6ea67d024575fafc2a813027cf374b8f24f7bc233c6b6be12"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +540,7 @@ dependencies = [
  "ansi-to-html",
  "basic-toml",
  "clap",
+ "clap_complete",
  "dirs-next",
  "fake-tty",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,10 @@ serde = { version = "1.0.159", features = ["derive"] }
 basic-toml = "0.1.2"
 thiserror = "1.0.40"
 
+[build-dependencies]
+clap = { version = "4.1.10", features = ["derive"] }
+clap_complete = "4.3.0"
+
 [profile.dev.package."*"]
 opt-level = 1
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,19 @@
+include!("src/opts/cli.rs");
+
+fn main() {
+    use std::{env, fs};
+
+    use clap::{CommandFactory, ValueEnum};
+    use clap_complete::{generate_to, Shell};
+
+    let out_dir = env::var("SHELL_COMPLETIONS_DIR")
+        .or_else(|_| env::var("OUT_DIR"))
+        .unwrap();
+
+    fs::create_dir_all(&out_dir).unwrap();
+
+    let mut cmd = Cli::command();
+    for &shell in Shell::value_variants() {
+        generate_to(shell, &mut cmd, "to-html", &out_dir).unwrap();
+    }
+}


### PR DESCRIPTION
Resolves #21 

Adds in shell completions using a build script to either the default `$OUT_DIR` (nestled within the target directory) or to the provided `$SHELL_COMPLETIONS_DIR`. This also adjusts the release workflow to provide a compressed archive including the generated completions (the release action was changed with this, but the old release action was unmaintained according to their repo)

_Completions in action:_

![image](https://github.com/Aloso/to-html/assets/30302768/d2c2b777-d3d3-433c-b8b0-84988aa1e120)
