### PR TITLE
Added CLI argument to hide the executed command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,9 @@ fn main_inner() -> Result<(), StdError> {
 }
 
 fn fmt_command(buf: &mut String, command: &str, opts: &Opts) -> Result<(), StdError> {
-    fmt_command_prompt(buf, command, opts)?;
+    if !opts.hide_prompt {
+        fmt_command_prompt(buf, command, opts)?;
+    }
 
     let var_prefix = if opts.prefix.is_empty() {
         None

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main_inner() -> Result<(), StdError> {
 }
 
 fn fmt_command(buf: &mut String, command: &str, opts: &Opts) -> Result<(), StdError> {
-    if !opts.hide_prompt {
+    if !opts.no_prompt {
         fmt_command_prompt(buf, command, opts)?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main_inner() -> Result<(), StdError> {
         }
     }
 
-    if !opts.no_run {
+    if !opts.no_run && !opts.no_prompt {
         shell_prompt(&mut buf, &opts)?;
         writeln!(buf, "<span class='{p}caret'> </span>", p = opts.prefix)?;
     }

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -42,4 +42,7 @@ pub struct Cli {
     /// Output a complete HTML document, not just a `<pre>`
     #[arg(short, long)]
     pub doc: bool,
+    /// Do not show the command prompt
+    #[arg(short = 'H', long)]
+    pub hide_prompt: bool,
 }

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -33,16 +33,16 @@ pub struct Cli {
     /// `to-html-arg`
     #[arg(short, long)]
     pub prefix: Option<String>,
-    /// Don't run the commands, just emit the HTML for the command prompt
-    #[arg(short, long, group = "no_prompt_or_run")]
+    /// Do not run the commands, just emit the HTML for the command prompt
+    #[arg(short = 'n', long, group = "no_prompt_or_run")]
     pub no_run: bool,
+    /// Do not show the command prompt
+    #[arg(short = 'N', long, group = "no_prompt_or_run")]
+    pub no_prompt: bool,
     /// Print the (abbreviated) current working directory in the command prompt
     #[arg(short, long)]
     pub cwd: bool,
     /// Output a complete HTML document, not just a `<pre>`
     #[arg(short, long)]
     pub doc: bool,
-    /// Do not show the command prompt
-    #[arg(short = 'H', long, group = "no_prompt_or_run")]
-    pub no_prompt: bool,
 }

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -34,7 +34,7 @@ pub struct Cli {
     #[arg(short, long)]
     pub prefix: Option<String>,
     /// Don't run the commands, just emit the HTML for the command prompt
-    #[arg(short, long)]
+    #[arg(short, long, group = "no_prompt_or_run")]
     pub no_run: bool,
     /// Print the (abbreviated) current working directory in the command prompt
     #[arg(short, long)]
@@ -43,6 +43,6 @@ pub struct Cli {
     #[arg(short, long)]
     pub doc: bool,
     /// Do not show the command prompt
-    #[arg(short = 'H', long)]
-    pub hide_prompt: bool,
+    #[arg(short = 'H', long, group = "no_prompt_or_run")]
+    pub no_prompt: bool,
 }

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -22,7 +22,7 @@ pub struct Opts {
     pub no_run: bool,
     pub prompt: ShellPrompt,
     pub doc: bool,
-    pub hide_prompt: bool,
+    pub no_prompt: bool,
 }
 
 impl Opts {
@@ -48,7 +48,7 @@ impl Opts {
             no_run: cli_no_run,
             cwd: cli_cwd,
             doc: cli_doc,
-            hide_prompt: cli_hide_prompt,
+            no_prompt: cli_no_prompt,
         } = cli::parse();
 
         let prompt = if cli_cwd || config_cwd {
@@ -71,7 +71,7 @@ impl Opts {
             no_run: cli_no_run,
             prompt,
             doc: cli_doc || config_doc,
-            hide_prompt: cli_hide_prompt,
+            no_prompt: cli_no_prompt,
         })
     }
 }

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -22,6 +22,7 @@ pub struct Opts {
     pub no_run: bool,
     pub prompt: ShellPrompt,
     pub doc: bool,
+    pub hide_prompt: bool,
 }
 
 impl Opts {
@@ -47,6 +48,7 @@ impl Opts {
             no_run: cli_no_run,
             cwd: cli_cwd,
             doc: cli_doc,
+            hide_prompt: cli_hide_prompt,
         } = cli::parse();
 
         let prompt = if cli_cwd || config_cwd {
@@ -69,6 +71,7 @@ impl Opts {
             no_run: cli_no_run,
             prompt,
             doc: cli_doc || config_doc,
+            hide_prompt: cli_hide_prompt,
         })
     }
 }


### PR DESCRIPTION
The current version works fine for command outputs. But if you only want to format a file, you get a command prompt containing the entire command. 

![2023-11-27_08-52](https://github.com/Aloso/to-html/assets/28309938/3e5134bb-f824-4c33-8c5c-e137864cb2e7)

This PR adds a new argument that removes the first line for cases where the user wants to use a custom prompt or none.