### PR TITLE
Allow semicolons before terminators

### DIFF
--- a/crates/ansi-to-html/src/html/mod.rs
+++ b/crates/ansi-to-html/src/html/mod.rs
@@ -78,9 +78,10 @@ pub fn ansi_to_html(
                 }
 
                 let nums = &m.as_str()[2..len - 1];
-                let nums = nums.split(';').map(|n| n.parse::<u8>());
+                let norm_nums = nums.strip_suffix(';').unwrap_or(nums);
+                let norm_nums = norm_nums.split(';').map(|n| n.parse::<u8>());
 
-                for ansi in AnsiIter::new(nums) {
+                for ansi in AnsiIter::new(norm_nums) {
                     minifier.push_ansi_code(ansi?);
                 }
             }

--- a/crates/ansi-to-html/tests/ansi_to_html.rs
+++ b/crates/ansi-to-html/tests/ansi_to_html.rs
@@ -88,3 +88,9 @@ fn ariadne() {
     <span style='color:#949494'>---&#39;</span>
     "###);
 }
+
+#[test]
+fn semicolon_before_terminator() {
+    let converted = ansi_to_html::convert("\x1b[31;mRed\x1b[0;m Plain").unwrap();
+    insta::assert_snapshot!(converted, @"<span style='color:var(--red,#a00)'>Red</span> Plain");
+}


### PR DESCRIPTION
Fixes #30

Allows for a single optional semicolon in ansi codes before the terminating `m`