### PR TITLE
CI tweaks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Print information
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 0 1 * *'
 
 jobs:
-  rustfmt:
+  lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,31 +19,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.channel }}
-          components: rustfmt
-      - uses: actions/checkout@v4
+          components: clippy, rustfmt
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Run `cargo fmt`
         run: |
           cargo fmt --all -- --check
-
-  clippy:
-    needs: rustfmt
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        channel: [stable, beta]
-    steps:
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.channel }}
-          components: clippy
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Run `cargo clippy`
         run: |
           cargo clippy
 
-  build:
-    needs: clippy
+  test:
+    needs: lint
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           toolchain: ${{ matrix.channel }}
           components: rustfmt
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run `cargo fmt`
         run: |
           cargo fmt --all -- --check
@@ -35,7 +35,7 @@ jobs:
           toolchain: ${{ matrix.channel }}
           components: clippy
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run `cargo clippy`
         run: |
           cargo clippy
@@ -52,7 +52,7 @@ jobs:
         with:
           toolchain: ${{ matrix.channel }}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build and run tests
         run: |
           cargo test --verbose --workspace

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+    - main
   pull_request:
   schedule:
     # Run monthly to keep Rust toolchain changes fresh


### PR DESCRIPTION
The last two commits are the opinionated parts. The first avoids triggering two CI jobs for each push to a PR while the last combines the current `rustfmt` and `clippy` jobs since `rustfmt` will finish ~instantaneously