### PR TITLE
Drop `thiserror` in favor of a manual impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,7 +17,6 @@ version = "0.2.2"
 dependencies = [
  "insta",
  "regex",
- "thiserror",
 ]
 
 [[package]]

--- a/crates/ansi-to-html/Cargo.toml
+++ b/crates/ansi-to-html/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["color", "cli", "terminal", "html"]
 
 [dependencies]
 regex = "1.7.3"
-thiserror = "1.0.40"
 
 [features]
 default = []

--- a/crates/ansi-to-html/src/error.rs
+++ b/crates/ansi-to-html/src/error.rs
@@ -1,16 +1,31 @@
-use std::num::ParseIntError;
+use std::{fmt, num::ParseIntError};
 
 /// Errors that can occur when converting an ANSI string to HTML
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum Error {
     /// Parsing a number was unsuccessful
-    #[error(transparent)]
-    ParseInt(#[from] ParseIntError),
+    ParseInt(ParseIntError),
 
     /// The ANSI escape code is invalid
-    #[error("Invalid ANSI: {msg}")]
     InvalidAnsi { msg: String },
 }
+
+impl From<ParseIntError> for Error {
+    fn from(err: ParseIntError) -> Self {
+        Self::ParseInt(err)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ParseInt(err) => write!(f, "{}", err),
+            Self::InvalidAnsi { msg } => write!(f, "Invalid ANSI: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 impl Error {
     pub(crate) fn invalid_ansi(s: &'static str) -> impl Fn() -> Self {


### PR DESCRIPTION
Because it's easy enough for this crate and drops a good chunk of its dep tree