### PR TITLE
fix(ansi-to-html): don't minify when skipping optimizations

### DIFF
--- a/crates/ansi-to-html/fuzz/utils/html_interpreter.rs
+++ b/crates/ansi-to-html/fuzz/utils/html_interpreter.rs
@@ -334,7 +334,19 @@ mod tests {
     }
 
     #[test]
-    fn input_blue_red_text_red_text() {
+    fn optimizations_respect_different_underlines() {
+        // Input -> double underline -> "Double" -> reset -> underline -> " Single"
+        let ansi_text = "\x1b[21mDouble\x1b[0;4m Single";
+        assert_opt_equiv_to_no_opt(ansi_text);
+        let htmlified = ansi_to_html::convert(ansi_text).unwrap();
+        insta::assert_snapshot!(
+            htmlified,
+            @"<u style='text-decoration-style:double'>Double</u><u> Single</u>"
+        );
+    }
+
+    #[test]
+    fn competing_colors() {
         // Input: blue -> red -> "Red" -> red -> " Still Red"
         let ansi_text = "\x1b[34;31mRed\x1b[31m Still Red";
         assert_opt_equiv_to_no_opt(ansi_text);

--- a/crates/ansi-to-html/fuzz/utils/html_interpreter.rs
+++ b/crates/ansi-to-html/fuzz/utils/html_interpreter.rs
@@ -399,4 +399,11 @@ mod tests {
             @"<u><span style='color:var(--blue,#00a)'></span></u><span style='color:var(--blue,#00a)'><span style='color:var(--red,#a00)'>Red Still Red</span></span>"
         );
     }
+
+    #[test]
+    fn debug_this() {
+        // Input: blue bg -> black bg -> invert -> A -> black bg -> B
+        let ansi_text = "\u{1b}[44;40;7mA\u{1b}[40mB";
+        assert_opt_equiv_to_no_opt(ansi_text);
+    }
 }

--- a/crates/ansi-to-html/src/lib.rs
+++ b/crates/ansi-to-html/src/lib.rs
@@ -181,11 +181,12 @@ impl Converter {
             theme,
         } = *self;
 
+        let four_bit_var_prefix = four_bit_var_prefix.to_owned();
         let html = if skip_escape {
-            html::ansi_to_html(input, four_bit_var_prefix.to_owned(), theme)?
+            html::ansi_to_html(input, four_bit_var_prefix, theme, skip_optimize)?
         } else {
             let input = Esc(input).to_string();
-            html::ansi_to_html(&input, four_bit_var_prefix.to_owned(), theme)?
+            html::ansi_to_html(&input, four_bit_var_prefix, theme, skip_optimize)?
         };
 
         let html = if skip_optimize { html } else { optimize(&html) };


### PR DESCRIPTION
_from: https://github.com/Aloso/to-html/issues/37#issue-2708292856_

> **me:** Really we should only apply the minifier when optimizations are enabled, ...

Only runs the minifier which coalesces runs of text that re-apply the same style when optimizations are enabled

This did involve some internal refactoring to expose both the `Minifier` and the `AnsiConverter` behind the same `AnsiSink` trait, so that they can be used interchangeably. That change required some tweaks to make things dyn-compatible[^1], but nothing too drastic

## ~~a :bug: surfaces~~ (resolved!)

<details>
<summary>Resolved in #47</summary>

The reason that this is a draft, is because these changes cause the fuzzer to crash in a rather  peculiar way represented by the following test

```rust
#[test]
fn debug_this() {
    // Input: red -> "Red" -> blue -> red -> " Still Red"
    let ansi_text = "\x1b[31mRed\x1b[34;31m Still Red";

    let opt = ansi_to_html::convert(ansi_text).unwrap();
    insta::assert_snapshot!(
        opt,
        @"<span style='color:var(--red,#a00)'>Red Still Red</span>"
    );
    let no_opt = ansi_to_html::Converter::new().skip_optimize(true).convert(ansi_text).unwrap();
    insta::assert_snapshot!(
        no_opt,
        @"<span style='color:var(--red,#a00)'>Red<span style='color:var(--blue,#00a)'> Still Red</span></span>"
    );

    assert_opt_equiv_to_no_opt(ansi_text);
}
```

And a quick sanity check in wezterm

![image](https://github.com/user-attachments/assets/96d48f7f-a802-41e6-9035-44cf2038990d)

As you can see without optimizations applied the `Still Red` gets styled as blue even though red is applied again immediately after the blue. The optimized version is thankfully correct. I'll try to track down the underlying bug, so that it can get addressed before/with this PR

---

These changes also picked up another crash in the fuzzer earlier, but that was just a bug in the fuzz target where text could be interpreted as having multiple colors. Resolving that was as simple as teaching the interpreter how to handle all of our spans that we emit

</details>

[^1]: or w/e phrase it is that's replacing object safe