### PR TITLE
Benchmark more converter configurations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,8 @@ opt-level = 1
 [profile.release]
 lto = "thin"
 strip = true
+
+[profile.release-debug]
+inherits = "release"
+strip = false
+debug = true

--- a/crates/ansi-to-html/benches/convert.rs
+++ b/crates/ansi-to-html/benches/convert.rs
@@ -1,5 +1,6 @@
 use std::{hint::black_box, io::Read, time::Duration};
 
+use ansi_to_html::Converter;
 use divan::{bench, counter::BytesCount, Bencher, Divan};
 use flate2::bufread::GzDecoder;
 
@@ -12,14 +13,52 @@ fn main() {
 
 static COMPRESSED_TERMINAL_SESSION: &[u8] = include_bytes!("../assets/terminal_session.gz");
 
-#[bench]
-fn convert(bencher: Bencher) {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Input {
+    AnsiHeavy,
+    PlainText,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MaybeEsc {
+    Esc,
+    SkipEsc,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MaybeOpt {
+    Opt,
+    SkipOpt,
+}
+
+#[bench(args = [
+    (Input::AnsiHeavy, MaybeEsc::Esc, MaybeOpt::Opt),
+    (Input::AnsiHeavy, MaybeEsc::Esc, MaybeOpt::SkipOpt),
+    (Input::AnsiHeavy, MaybeEsc::SkipEsc, MaybeOpt::Opt),
+    (Input::AnsiHeavy, MaybeEsc::SkipEsc, MaybeOpt::SkipOpt),
+    (Input::PlainText, MaybeEsc::Esc, MaybeOpt::Opt),
+    (Input::PlainText, MaybeEsc::Esc, MaybeOpt::SkipOpt),
+    (Input::PlainText, MaybeEsc::SkipEsc, MaybeOpt::Opt),
+    (Input::PlainText, MaybeEsc::SkipEsc, MaybeOpt::SkipOpt),
+])]
+fn convert(bencher: Bencher, (input, esc, opt): (Input, MaybeEsc, MaybeOpt)) {
     let mut decoder = GzDecoder::new(COMPRESSED_TERMINAL_SESSION);
     let mut terminal_session = String::new();
     decoder.read_to_string(&mut terminal_session).unwrap();
 
+    if input == Input::PlainText {
+        // Replace the start of all ansi escape sequences with a benign character to "strip" all of
+        // the ansi codes (well replace them with non-ansi garbage)
+        terminal_session = terminal_session.replace('\u{1b}', "~");
+    }
+
     let bytes_counter = BytesCount::of_str(&terminal_session);
+
+    let converter = Converter::new()
+        .skip_escape(esc == MaybeEsc::SkipEsc)
+        .skip_optimize(opt == MaybeOpt::SkipOpt);
+
     bencher
         .counter(bytes_counter)
-        .bench(|| ansi_to_html::convert(black_box(&terminal_session)).unwrap());
+        .bench(|| converter.convert(black_box(&terminal_session)).unwrap());
 }


### PR DESCRIPTION
Expands the existing `convert` benchmark to test all of the various combinations of `.skip_escape()` and `.skip_optimize()`

```console
$ c bench
...
     Running benches/convert.rs (/home/wintermute/Programming/Repos/to-html/target/release/deps/convert-5e5e50067c6a95a7)
Timer precision: 12 ns
convert                         fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ convert                                    │               │               │               │         │
   ├─ (Optimized, Escaped)      2.131 ms      │ 2.863 ms      │ 2.145 ms      │ 2.155 ms      │ 228     │ 228
   │                            65.21 MB/s    │ 48.55 MB/s    │ 64.81 MB/s    │ 64.5 MB/s     │         │
   ├─ (Optimized, Unescaped)    1.473 ms      │ 1.755 ms      │ 1.493 ms      │ 1.505 ms      │ 333     │ 333
   │                            94.36 MB/s    │ 79.2 MB/s     │ 93.09 MB/s    │ 92.34 MB/s    │         │
   ├─ (Unoptimized, Escaped)    1.767 ms      │ 2.056 ms      │ 1.793 ms      │ 1.803 ms      │ 278     │ 278
   │                            78.68 MB/s    │ 67.61 MB/s    │ 77.5 MB/s     │ 77.09 MB/s    │         │
   ╰─ (Unoptimized, Unescaped)  1.219 ms      │ 1.374 ms      │ 1.233 ms      │ 1.242 ms      │ 403     │ 403
                                114 MB/s      │ 101.1 MB/s    │ 112.7 MB/s    │ 111.9 MB/s    │         │
```

I also opted to add a `release-debug` build profile that builds with optimizations while retaining debuginfo. In combination with the other changes in this PR it allows for profiling various specific converter configurations by filtering the benchmark you want to run. E.g. looking at the speed while skipping optimizations and escaping HTML chars

```console
$ c bench --no-run --profile=release-debug
...
    Finished `release-debug` profile [optimized + debuginfo] target(s) in 19.46s
  Executable benches src/lib.rs (/.../to-html/target/release-debug/deps/ansi_to_html-61953fe8728cdbac)
  Executable benches/convert.rs (/.../to-html/target/release-debug/deps/convert-0cbc1aa131d90c86)
$ samply record ../../target/release-debug/deps/convert-0cbc1aa131d90c86 --bench --min-time=10 '(Unoptimized, Escaped)'
Timer precision: 40 ns
convert                       fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ convert                                  │               │               │               │         │
   ╰─ (Unoptimized, Escaped)  1.738 ms      │ 3.353 ms      │ 1.775 ms      │ 1.785 ms      │ 5591    │ 5591
                              79.98 MB/s    │ 41.45 MB/s    │ 78.3 MB/s     │ 77.86 MB/s    │         │

Local server listening at http://127.0.0.1:3000
Press Ctrl+C to stop.
^C
```
