### PR TITLE
docs(ansi-to-html): Add a pipe example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
 name = "ansi-to-html"
 version = "0.2.2"
 dependencies = [
+ "clap",
  "divan",
  "flate2",
  "insta",
@@ -135,9 +136,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -145,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -167,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -179,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"

--- a/crates/ansi-to-html/Cargo.toml
+++ b/crates/ansi-to-html/Cargo.toml
@@ -21,6 +21,7 @@ default = []
 lazy-init = []
 
 [dev-dependencies]
+clap = { version = "4.5.27", features = ["derive"] }
 divan = "0.1.16"
 flate2 = "1.0.35"
 insta = "1.29.0"

--- a/crates/ansi-to-html/examples/htmlpipe.rs
+++ b/crates/ansi-to-html/examples/htmlpipe.rs
@@ -1,0 +1,39 @@
+use std::io::{self, Read};
+
+use clap::Parser;
+
+/// A small demo that converts ANSI stdin to HTML. Typical usage would be something like
+///
+/// $ echo -e 'Plain \e[1mBold' | cargo run -q --example pipe > output.html
+///
+/// $ firefox output.html
+#[derive(Parser, Debug)]
+#[command(about)]
+struct Args {
+    /// Skip escaping special HTML characters before conversion
+    #[arg(long)]
+    skip_escape: bool,
+    /// Skip optimized the converted HTML
+    #[arg(long)]
+    skip_optimize: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse our CLI args
+    let Args {
+        skip_escape,
+        skip_optimize,
+    } = Args::parse();
+
+    // HTMLify our stdin
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    let htmlified = ansi_to_html::Converter::new()
+        .skip_escape(skip_escape)
+        .skip_optimize(skip_optimize)
+        .convert(&input)?;
+
+    // Wrapping the output in `<pre>` to preserve the whitespace
+    println!("<pre>\n{htmlified}</pre>");
+    Ok(())
+}


### PR DESCRIPTION
Adds a very basic `htmlpipe` example to `ansi-to-html` that just converts input fed to it into html

```console
$ c r -q --example htmlpipe -- --help
A small demo that converts ANSI stdin to HTML. Typical usage would be something like

 $ echo -e 'Plain \e[1mBold' | cargo run -q --example pipe > output.html

 $ firefox output.html

Usage: htmlpipe [OPTIONS]

Options:
      --skip-escape
          Skip escaping special HTML characters before conversion

      --skip-optimize
          Skip optimized the converted HTML

  -h, --help
          Print help (see a summary with '-h')
```