### PR TITLE
refactor(ansi-to-html): Avoid peeking while parsing ANSI codes

### DIFF
--- a/crates/ansi-to-html/src/ansi/parse.rs
+++ b/crates/ansi-to-html/src/ansi/parse.rs
@@ -1,4 +1,4 @@
-use std::{mem, ops::Range, str::CharIndices};
+use std::str::CharIndices;
 
 const ESCAPE: char = '\u{1b}';
 
@@ -6,51 +6,24 @@ const ESCAPE: char = '\u{1b}';
 pub(crate) struct AnsiParser<'text> {
     text: &'text str,
     chars: CharIndices<'text>,
-    /// Stores whether the last iteration of `.next()` ended on an escape character
+    /// Potentially stores the character that broke us out of the last `.next()` call
     ///
-    /// The parser sifts through text to find ANSI codes which **always** start with an escape
-    /// character. We can exploit this to speed up the hot path of iterating over plain text by
-    /// unconditionally iterating over characters and storing whether the character that broke us
-    /// out was an escape in this field. This avoids the need to peek each character to see if it's
-    /// the start of an ANSI code by re-framing the ansi code parsing to start _after_ the intial
-    /// escape and adjusting the starting index to still include it
-    was_on_esc: bool,
+    /// In the case of an invalid/unrecognized ANSI code or when iterating over plain text portions
+    /// the character that breaks us out of the current token that we're parsing (e.g. when we see
+    /// an escape while parsing plain text) will be stored in this field and taken into account on
+    /// the start of the next iteration. This removes the need to peek each character to avoid
+    /// advancing the iterator by retaining the character for next iteration instead
+    ended_last_iter_on: Option<char>,
 }
 
 impl<'text> AnsiParser<'text> {
     pub(crate) fn new(text: &'text str) -> Self {
         let chars = text.char_indices();
-        let was_on_esc = false;
+        let ended_last_iter_on = None;
         Self {
             text,
             chars,
-            was_on_esc,
-        }
-    }
-
-    fn parse_ansi_code_after_esc(&mut self) -> Option<AnsiFragment<'text>> {
-        let mut fsm = AnsiFsm::new(&mut self.chars);
-        loop {
-            let Some(status) = fsm.peek() else {
-                break Some(AnsiFragment::Text(&self.text[fsm.span()]));
-            };
-
-            match status {
-                Status::InSequence => _ = fsm.next(),
-                Status::Accept => {
-                    fsm.next();
-                    break Some(AnsiFragment::Sequence(&self.text[fsm.span()]));
-                }
-                // NOTE(cosmic): niche case, but behavior is diverging from the regex here
-                // which would return invalid ansi codes _along with_ any surround text whereas
-                // we're emitting them separately atm
-                Status::RejectAsText => {
-                    // Fortunately the starting ESC of an ANSI sequence can't appear within
-                    // the sequence itself, so we don't need to worry about any backtracking or
-                    // reparsing
-                    break Some(AnsiFragment::Text(&self.text[fsm.span()]));
-                }
-            }
+            ended_last_iter_on,
         }
     }
 }
@@ -65,65 +38,53 @@ impl<'text> Iterator for AnsiParser<'text> {
     type Item = AnsiFragment<'text>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if mem::take(&mut self.was_on_esc) {
-            self.parse_ansi_code_after_esc()
-        } else {
-            let start_idx = self.chars.offset();
-            let (_, c) = self.chars.next()?;
-            if c == ESCAPE {
-                return self.parse_ansi_code_after_esc();
+        let ended_last_iter_on = self.ended_last_iter_on.take();
+        let start_idx = self.chars.offset() - ended_last_iter_on.map(char::len_utf8).unwrap_or(0);
+        let c = ended_last_iter_on.or_else(|| self.chars.next().map(|(_, c)| c))?;
+        // All ANSI codes start with ESCAPE, so check if we're parsing an ANSI code or plain text
+        // with this iteration
+        if c == ESCAPE {
+            let mut state = State::default();
+            loop {
+                let Some((_, c)) = self.chars.next() else {
+                    break Some(AnsiFragment::Text(
+                        &self.text[start_idx..self.chars.offset()],
+                    ));
+                };
+
+                state.munch(c);
+                match state.into() {
+                    Status::InSequence => {}
+                    Status::Accept => {
+                        break Some(AnsiFragment::Sequence(
+                            &self.text[start_idx..self.chars.offset()],
+                        ));
+                    }
+                    // NOTE(cosmic): niche case, but behavior is diverging from the regex here
+                    // which would return invalid ansi codes _along with_ any surround text whereas
+                    // we're emitting them separately atm
+                    Status::RejectAsText => {
+                        self.ended_last_iter_on = Some(c);
+                        // Fortunately the starting ESC of an ANSI sequence can't appear within
+                        // the sequence itself, so we don't need to worry about any backtracking or
+                        // reparsing
+                        break Some(AnsiFragment::Text(
+                            &self.text[start_idx..self.chars.offset() - c.len_utf8()],
+                        ));
+                    }
+                }
             }
+        } else {
             while let Some((_, c)) = self.chars.next() {
                 if c == ESCAPE {
-                    self.was_on_esc = true;
+                    self.ended_last_iter_on = Some(c);
                     break;
                 }
             }
-            let end_offset = if self.was_on_esc {
-                ESCAPE.len_utf8()
-            } else {
-                0
-            };
+            let end_offset = self.ended_last_iter_on.map(char::len_utf8).unwrap_or(0);
             let end_idx = self.chars.offset() - end_offset;
             Some(AnsiFragment::Text(&self.text[start_idx..end_idx]))
         }
-    }
-}
-
-/// A small finite state machine that parses ANSI codes after the initial ESC
-struct AnsiFsm<'short, 'text: 'short> {
-    chars: &'short mut CharIndices<'text>,
-    state: State,
-    start_idx: usize,
-}
-
-impl<'short, 'text> AnsiFsm<'short, 'text> {
-    fn new(chars: &'short mut CharIndices<'text>) -> Self {
-        let state = State::default();
-        let start_idx = chars.offset() - ESCAPE.len_utf8();
-        Self {
-            chars,
-            state,
-            start_idx,
-        }
-    }
-
-    fn peek(&self) -> Option<Status> {
-        let mut chars_lookahead = self.chars.to_owned();
-        let mut state_lookahead = self.state.to_owned();
-        let (_, c) = chars_lookahead.next()?;
-        state_lookahead.munch(c);
-        Some(state_lookahead.into())
-    }
-
-    fn next(&mut self) -> Option<Status> {
-        let (_, c) = self.chars.next()?;
-        self.state.munch(c);
-        Some(self.state.into())
-    }
-
-    fn span(self) -> Range<usize> {
-        self.start_idx..self.chars.offset()
     }
 }
 

--- a/crates/ansi-to-html/src/ansi/parse.rs
+++ b/crates/ansi-to-html/src/ansi/parse.rs
@@ -1,15 +1,57 @@
-use std::{ops::Range, str::CharIndices};
+use std::{mem, ops::Range, str::CharIndices};
+
+const ESCAPE: char = '\u{1b}';
 
 #[must_use]
 pub(crate) struct AnsiParser<'text> {
     text: &'text str,
     chars: CharIndices<'text>,
+    /// Stores whether the last iteration of `.next()` ended on an escape character
+    ///
+    /// The parser sifts through text to find ANSI codes which **always** start with an escape
+    /// character. We can exploit this to speed up the hot path of iterating over plain text by
+    /// unconditionally iterating over characters and storing whether the character that broke us
+    /// out was an escape in this field. This avoids the need to peek each character to see if it's
+    /// the start of an ANSI code by re-framing the ansi code parsing to start _after_ the intial
+    /// escape and adjusting the starting index to still include it
+    was_on_esc: bool,
 }
 
 impl<'text> AnsiParser<'text> {
     pub(crate) fn new(text: &'text str) -> Self {
         let chars = text.char_indices();
-        Self { text, chars }
+        let was_on_esc = false;
+        Self {
+            text,
+            chars,
+            was_on_esc,
+        }
+    }
+
+    fn parse_ansi_code_after_esc(&mut self) -> Option<AnsiFragment<'text>> {
+        let mut fsm = AnsiFsm::new(&mut self.chars);
+        loop {
+            let Some(status) = fsm.peek() else {
+                break Some(AnsiFragment::Text(&self.text[fsm.span()]));
+            };
+
+            match status {
+                Status::InSequence => _ = fsm.next(),
+                Status::Accept => {
+                    fsm.next();
+                    break Some(AnsiFragment::Sequence(&self.text[fsm.span()]));
+                }
+                // NOTE(cosmic): niche case, but behavior is diverging from the regex here
+                // which would return invalid ansi codes _along with_ any surround text whereas
+                // we're emitting them separately atm
+                Status::RejectAsText => {
+                    // Fortunately the starting ESC of an ANSI sequence can't appear within
+                    // the sequence itself, so we don't need to worry about any backtracking or
+                    // reparsing
+                    break Some(AnsiFragment::Text(&self.text[fsm.span()]));
+                }
+            }
+        }
     }
 }
 
@@ -23,61 +65,47 @@ impl<'text> Iterator for AnsiParser<'text> {
     type Item = AnsiFragment<'text>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut dfa = Dfa::new(&mut self.chars).unwrap();
-
-        match dfa.next()? {
-            // Walk through the current run of text
-            Status::Waiting => {
-                while dfa.peek() == Some(Status::Waiting) {
-                    dfa.next();
-                }
-                Some(AnsiFragment::Text(&self.text[dfa.span()]))
+        if mem::take(&mut self.was_on_esc) {
+            self.parse_ansi_code_after_esc()
+        } else {
+            let start_idx = self.chars.offset();
+            let (_, c) = self.chars.next()?;
+            if c == ESCAPE {
+                return self.parse_ansi_code_after_esc();
             }
-            // Walk through the ansi sequence
-            Status::InSequence => loop {
-                let Some(status) = dfa.peek() else {
-                    break Some(AnsiFragment::Text(&self.text[dfa.span()]));
-                };
-
-                match status {
-                    Status::Waiting => unreachable!("We're already past `Waiting`"),
-                    Status::InSequence => _ = dfa.next(),
-                    Status::Accept => {
-                        dfa.next();
-                        break Some(AnsiFragment::Sequence(&self.text[dfa.span()]));
-                    }
-                    // TODO(cosmic): niche case, but behavior is diverging from the regex here
-                    // which would return invalid ansi codes _along with_ any surround text whereas
-                    // we're emitting them separately atm
-                    Status::RejectAsText => {
-                        // Fortunately the starting ESC of an ANSI sequence can't appear within
-                        // the sequence itself, so we don't need to worry about any backtracking or
-                        // reparsing
-                        break Some(AnsiFragment::Text(&self.text[dfa.span()]));
-                    }
+            while let Some((_, c)) = self.chars.next() {
+                if c == ESCAPE {
+                    self.was_on_esc = true;
+                    break;
                 }
-            },
-            _ => unreachable!("No other possible statuses after just one char"),
+            }
+            let end_offset = if self.was_on_esc {
+                ESCAPE.len_utf8()
+            } else {
+                0
+            };
+            let end_idx = self.chars.offset() - end_offset;
+            Some(AnsiFragment::Text(&self.text[start_idx..end_idx]))
         }
     }
 }
 
-/// A small DFA that detects and emits ANSI codes from an underlying `CharIndices`
-struct Dfa<'short, 'text: 'short> {
+/// A small finite state machine that parses ANSI codes after the initial ESC
+struct AnsiFsm<'short, 'text: 'short> {
     chars: &'short mut CharIndices<'text>,
     state: State,
     start_idx: usize,
 }
 
-impl<'short, 'text> Dfa<'short, 'text> {
-    fn new(chars: &'short mut CharIndices<'text>) -> Option<Self> {
+impl<'short, 'text> AnsiFsm<'short, 'text> {
+    fn new(chars: &'short mut CharIndices<'text>) -> Self {
         let state = State::default();
-        let start_idx = chars.offset();
-        Some(Self {
+        let start_idx = chars.offset() - ESCAPE.len_utf8();
+        Self {
             chars,
             state,
             start_idx,
-        })
+        }
     }
 
     fn peek(&self) -> Option<Status> {
@@ -101,12 +129,10 @@ impl<'short, 'text> Dfa<'short, 'text> {
 
 #[derive(Clone, Copy, Default)]
 enum State {
-    /// Waiting to see an escape
     #[default]
-    Init,
+    Escape,
     Trap,
     Accept,
-    Escape,
     EscapeOpenParen,
     /// Control Sequence Introducer (CSI) - Indicates the start of an ansi sequence
     Csi,
@@ -117,9 +143,6 @@ enum State {
 impl State {
     fn munch(&mut self, c: char) {
         *self = match (*self, c) {
-            // Waiting for ESC
-            (Self::Init, '\u{1b}') => Self::Escape,
-            (Self::Init, _) => Self::Init,
             // Weird `<ESC>(B` ansi code
             (Self::Escape, '(') => Self::EscapeOpenParen,
             (Self::EscapeOpenParen, 'B') => Self::Accept,
@@ -139,7 +162,6 @@ impl State {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Status {
-    Waiting,
     InSequence,
     Accept,
     RejectAsText,
@@ -148,7 +170,6 @@ enum Status {
 impl From<State> for Status {
     fn from(state: State) -> Self {
         match state {
-            State::Init => Self::Waiting,
             State::Trap => Self::RejectAsText,
             State::Accept => Self::Accept,
             State::Escape
@@ -163,6 +184,19 @@ impl From<State> for Status {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn plain() {
+        let parser = AnsiParser::new("Hello World!");
+        let fragments: Vec<_> = parser.into_iter().collect();
+        insta::assert_debug_snapshot!(fragments, @r#"
+        [
+            Text(
+                "Hello World!",
+            ),
+        ]
+        "#);
+    }
 
     #[test]
     fn variety() {


### PR DESCRIPTION
This PR follows through with the optimization mentioned in https://github.com/Aloso/to-html/pull/45#discussion_r1912527412 where we can avoid peeking entirely when looking for the initial escape that starts an ANSI code by storing whether an escape character broke us out from a run of plain text

This **significantly** improves `ansi-to-html`'s performance across the board on #49's benchmarks. Mean times when running benches for 3 seconds for instance

|Bench | `main` | https://github.com/Aloso/to-html/pull/52/commits/438e13ad7abde565bd0fd0f53b65a43b5ac96ae3 alone | this PR |
| --: | :--: | :--: | :--: |
| (AnsiHeavy, Esc, Opt) | 63.94 MB/s | 82.22 MB/s | 92.55 MB/s |
| (AnsiHeavy, Esc, SkipOpt) | 76.54 MB/s | 104.3 MB/s | 122.1 MB/s |
| (AnsiHeavy, SkipEsc, Opt) | 89.43 MB/s | 127.8 MB/s | 148.5 MB/s |
| (AnsiHeavy, SkipEsc, SkipOpt) | 107.4 MB/s | 168.3 MB/s | 203 MB/s |
| (PlainText, Esc, Opt) | 108.6 MB/s | 215.7 MB/s | 228 MB/s |
| (PlainText, Esc, SkipOpt) | 109.6 MB/s | 217.5 MB/s | 228.8 MB/s |
| (PlainText, SkipEsc, Opt) | 182.5 MB/s| 1.005 GB/s | 1.007 GB/s |
| (PlainText, SkipEsc, SkipOpt) | 183 MB/s | 1.066 GB/s | 1.08 GB/s |