### PR TITLE
refactor(ansi-to-html): Escape text in chunks

### DIFF
--- a/crates/ansi-to-html/src/esc.rs
+++ b/crates/ansi-to-html/src/esc.rs
@@ -32,16 +32,47 @@ pub struct Esc<T: AsRef<str>>(pub T);
 
 impl<T: AsRef<str>> fmt::Display for Esc<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for c in self.0.as_ref().chars() {
-            match c {
-                '&' => fmt::Display::fmt("&amp;", f)?,
-                '<' => fmt::Display::fmt("&lt;", f)?,
-                '>' => fmt::Display::fmt("&gt;", f)?,
-                '"' => fmt::Display::fmt("&quot;", f)?,
-                '\'' => fmt::Display::fmt("&#39;", f)?,
-                c => fmt::Display::fmt(&c, f)?,
+        fn fmt_special_terminated_text(f: &mut fmt::Formatter<'_>, text: &str) -> fmt::Result {
+            debug_assert!(text.chars().filter(|c| SPECIAL_CHARS.contains(c)).count() == 1);
+            let special = text
+                .chars()
+                .last()
+                .expect("Must be called with text ending on a special char");
+            f.write_str(&text[..text.len() - special.len_utf8()])?;
+            let escaped = match special {
+                '&' => "&amp;",
+                '<' => "&lt;",
+                '>' => "&gt;",
+                '"' => "&quot;",
+                '\'' => "&#39;",
+                _ => unreachable!("We covered all patterns from `.ends_with(SPECIAL_CHARS)`"),
+            };
+            f.write_str(escaped)?;
+            Ok(())
+        }
+
+        const SPECIAL_CHARS: [char; 5] = ['&', '<', '>', '"', '\''];
+
+        let mut chunk_iter = self.0.as_ref().split_inclusive(SPECIAL_CHARS);
+        // All chunks aside from the last are guaranteed to be terminated with a special char
+        // > Differs from the iterator produced by `split` in that `split_inclusive` leaves the
+        // > matched part as the terminator of the substring.
+        let last_chunk = chunk_iter.next_back();
+        for chunk in chunk_iter {
+            fmt_special_terminated_text(f, chunk)?;
+        }
+        if let Some(chunk) = last_chunk {
+            // The last chunk might end with a special char
+            // > If the last element of the string is matched, that element will be considered the
+            // > terminator of the preceding substring. That substring will be the last item
+            // > returned by the iterator.
+            if chunk.ends_with(SPECIAL_CHARS) {
+                fmt_special_terminated_text(f, chunk)?;
+            } else {
+                f.write_str(chunk)?;
             }
         }
+
         Ok(())
     }
 }


### PR DESCRIPTION
Speeds up escaping text significantly by chunking the text using [`str::split_inclusive()`](https://doc.rust-lang.org/std/primitive.str.html#method.split_inclusive) instead of iterating over each individual character

All of the `Esc`aped benches from #49

| Input | Opt? | `main` | This PR |
| --: | :--: | :--: | :--: |
| ansi-heavy | :heavy_check_mark: | 62.94 MB/s | 74.94 MB/s |
| ansi-heavy | :x: | 75.46 MB/s | 93.52 MB/s |
| plain-text | :heavy_check_mark: | 109.9 MB/s | 149 MB/s |
| plain-text | :x: | 109.7 MB/s | 150.7 MB/s |