### PR TITLE
refactor(ansi-to-html): Switch parser from CharIndices to plain bytes

### DIFF
--- a/crates/ansi-to-html/src/ansi/parse.rs
+++ b/crates/ansi-to-html/src/ansi/parse.rs
@@ -1,30 +1,28 @@
-use std::str::CharIndices;
-
-const ESCAPE: char = '\u{1b}';
+const ESCAPE: u8 = 0x1b;
 
 #[must_use]
 pub(crate) struct AnsiParser<'text> {
     text: &'text str,
-    chars: CharIndices<'text>,
-    /// Potentially stores the character that broke us out of the last `.next()` call
-    ///
-    /// In the case of an invalid/unrecognized ANSI code or when iterating over plain text portions
-    /// the character that breaks us out of the current token that we're parsing (e.g. when we see
-    /// an escape while parsing plain text) will be stored in this field and taken into account on
-    /// the start of the next iteration. This removes the need to peek each character to avoid
-    /// advancing the iterator by retaining the character for next iteration instead
-    ended_last_iter_on: Option<char>,
+    index: usize,
 }
 
 impl<'text> AnsiParser<'text> {
     pub(crate) fn new(text: &'text str) -> Self {
-        let chars = text.char_indices();
-        let ended_last_iter_on = None;
-        Self {
-            text,
-            chars,
-            ended_last_iter_on,
-        }
+        let index = 0;
+        Self { text, index }
+    }
+
+    fn current_byte(&self) -> Option<u8> {
+        self.text.as_bytes().get(self.index).copied()
+    }
+
+    fn next_byte(&mut self) -> Option<u8> {
+        self.inc();
+        self.current_byte()
+    }
+
+    fn inc(&mut self) {
+        self.index += 1;
     }
 }
 
@@ -38,52 +36,41 @@ impl<'text> Iterator for AnsiParser<'text> {
     type Item = AnsiFragment<'text>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let ended_last_iter_on = self.ended_last_iter_on.take();
-        let start_idx = self.chars.offset() - ended_last_iter_on.map(char::len_utf8).unwrap_or(0);
-        let c = ended_last_iter_on.or_else(|| self.chars.next().map(|(_, c)| c))?;
+        let start_idx = self.index;
         // All ANSI codes start with ESCAPE, so check if we're parsing an ANSI code or plain text
         // with this iteration
-        if c == ESCAPE {
+        if self.current_byte()? == ESCAPE {
             let mut state = State::default();
             loop {
-                let Some((_, c)) = self.chars.next() else {
-                    break Some(AnsiFragment::Text(
-                        &self.text[start_idx..self.chars.offset()],
-                    ));
+                let Some(b) = self.next_byte() else {
+                    break Some(AnsiFragment::Text(&self.text[start_idx..self.index]));
                 };
 
-                state.munch(c);
+                state.munch(b);
                 match state.into() {
                     Status::InSequence => {}
                     Status::Accept => {
-                        break Some(AnsiFragment::Sequence(
-                            &self.text[start_idx..self.chars.offset()],
-                        ));
+                        self.inc();
+                        break Some(AnsiFragment::Sequence(&self.text[start_idx..self.index]));
                     }
                     // NOTE(cosmic): niche case, but behavior is diverging from the regex here
                     // which would return invalid ansi codes _along with_ any surround text whereas
                     // we're emitting them separately atm
                     Status::RejectAsText => {
-                        self.ended_last_iter_on = Some(c);
                         // Fortunately the starting ESC of an ANSI sequence can't appear within
                         // the sequence itself, so we don't need to worry about any backtracking or
                         // reparsing
-                        break Some(AnsiFragment::Text(
-                            &self.text[start_idx..self.chars.offset() - c.len_utf8()],
-                        ));
+                        break Some(AnsiFragment::Text(&self.text[start_idx..self.index]));
                     }
                 }
             }
         } else {
-            while let Some((_, c)) = self.chars.next() {
-                if c == ESCAPE {
-                    self.ended_last_iter_on = Some(c);
+            while let Some(b) = self.next_byte() {
+                if b == ESCAPE {
                     break;
                 }
             }
-            let end_offset = self.ended_last_iter_on.map(char::len_utf8).unwrap_or(0);
-            let end_idx = self.chars.offset() - end_offset;
-            Some(AnsiFragment::Text(&self.text[start_idx..end_idx]))
+            Some(AnsiFragment::Text(&self.text[start_idx..self.index]))
         }
     }
 }
@@ -102,18 +89,25 @@ enum State {
 }
 
 impl State {
-    fn munch(&mut self, c: char) {
-        *self = match (*self, c) {
+    fn munch(&mut self, b: u8) {
+        *self = match (*self, b) {
             // Weird `<ESC>(B` ansi code
-            (Self::Escape, '(') => Self::EscapeOpenParen,
-            (Self::EscapeOpenParen, 'B') => Self::Accept,
+            (Self::Escape, b'(') => Self::EscapeOpenParen,
+            (Self::EscapeOpenParen, b'B') => Self::Accept,
             // CSI-related codes
-            (Self::Escape, '[') => Self::Csi,
-            (Self::Csi | Self::Digit | Self::SemiColon, '0'..='9') => Self::Digit,
-            (Self::Digit, ';') => Self::SemiColon,
+            (Self::Escape, b'[') => Self::Csi,
+            (Self::Csi | Self::Digit | Self::SemiColon, b'0'..=b'9') => Self::Digit,
+            (Self::Digit, b';') => Self::SemiColon,
             (
                 Self::Csi | Self::Digit | Self::SemiColon,
-                'A'..='H' | 'J' | 'K' | 'S' | 'T' | 'f' | 'h' | 'i' | 'l' | 'm' | 'n' | 's' | 'u',
+                b'A'..=b'H'
+                | b'J'..=b'K'
+                | b'S'..=b'T'
+                | b'f'
+                | b'h'..=b'i'
+                | b'l'..=b'n'
+                | b's'
+                | b'u',
             ) => Self::Accept,
             // Anything else is invalid
             _ => Self::Trap,


### PR DESCRIPTION
We can parse everything as bytes because all of the byte values we're working with are in the ASCII range and all multi-byte UTF-8 codepoints are entirely made up of bytes outside the ASCII range

Better sets up for optionally depending on `memchr` along with a nice lil performance boost as a bonus

## Ansi Heavy Input

| Esc | Opt | `cosmic-dev` | this pr |
| :--: | :--: | :--: | :--: |
| :heavy_check_mark: | :heavy_check_mark: | 112.2 MB/s | 118.9 MB/s |
| :heavy_check_mark: | :x: | 156.5 MB/s | 168.5 MB/s |
| :x: | :heavy_check_mark: | 138 MB/s | 150.3 MB/s |
| :x: | :x: | 192.6 MB/s | 212.3 MB/s |

## Plain Text Input

| Esc | Opt | `cosmic-dev` | this pr |
| :--: | :--: | :--: | :--: |
| :heavy_check_mark: | :heavy_check_mark: | 439.4 MB/s | 534 MB/s |
| :heavy_check_mark: | :x: | 448.2 MB/s | 546.2 MB/s |
| :x: | :heavy_check_mark: | 976.9 MB/s | 1.501 GB/s |
| :x: | :x: | 1.051 GB/s | 1.668 GB/s |