### PR TITLE
refactor(ansi-to-html): Use `memchr` to find the initial escape byte

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "divan",
  "flate2",
  "insta",
+ "memchr",
  "regex",
 ]
 

--- a/crates/ansi-to-html/Cargo.toml
+++ b/crates/ansi-to-html/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 keywords = ["color", "cli", "terminal", "html"]
 
 [dependencies]
+memchr = "2.7.4"
 regex = "1.7.3"
 
 [features]

--- a/crates/ansi-to-html/src/ansi/parse.rs
+++ b/crates/ansi-to-html/src/ansi/parse.rs
@@ -65,11 +65,13 @@ impl<'text> Iterator for AnsiParser<'text> {
                 }
             }
         } else {
-            while let Some(b) = self.next_byte() {
-                if b == ESCAPE {
-                    break;
-                }
-            }
+            // Increment past the byte we just checked
+            self.inc();
+            // Find the next ESCAPE if there is one and adjust our index accordingly
+            match memchr::memchr(ESCAPE, &self.text.as_bytes()[start_idx..]) {
+                Some(end_offset) => self.index += end_offset - 1,
+                None => self.index = self.text.len(),
+            };
             Some(AnsiFragment::Text(&self.text[start_idx..self.index]))
         }
     }


### PR DESCRIPTION
Made `memchr` a hard dependency instead of optionally, but this regains most all of the lost performance on the ansi parsing heavy benches