### PR TITLE
refactor(ansi-to-html): Switch escaping to work on bytes

### DIFF
--- a/crates/ansi-to-html/src/esc.rs
+++ b/crates/ansi-to-html/src/esc.rs
@@ -32,47 +32,24 @@ pub struct Esc<T: AsRef<str>>(pub T);
 
 impl<T: AsRef<str>> fmt::Display for Esc<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fn fmt_special_terminated_text(f: &mut fmt::Formatter<'_>, text: &str) -> fmt::Result {
-            debug_assert!(text.chars().filter(|c| SPECIAL_CHARS.contains(c)).count() == 1);
-            let special = text
-                .chars()
-                .last()
-                .expect("Must be called with text ending on a special char");
-            f.write_str(&text[..text.len() - special.len_utf8()])?;
-            let escaped = match special {
-                '&' => "&amp;",
-                '<' => "&lt;",
-                '>' => "&gt;",
-                '"' => "&quot;",
-                '\'' => "&#39;",
+        let mut s = self.0.as_ref();
+        while let Some(pos) = s
+            .as_bytes()
+            .iter()
+            .position(|b| [b'&', b'<', b'>', b'"', b'\''].contains(&b))
+        {
+            f.write_str(&s[..pos])?;
+            let escaped = match s.as_bytes()[pos] {
+                b'&' => "&amp;",
+                b'<' => "&lt;",
+                b'>' => "&gt;",
+                b'"' => "&quot;",
+                b'\'' => "&#39;",
                 _ => unreachable!("We covered all patterns from `.ends_with(SPECIAL_CHARS)`"),
             };
             f.write_str(escaped)?;
-            Ok(())
+            s = &s[pos + 1..];
         }
-
-        const SPECIAL_CHARS: [char; 5] = ['&', '<', '>', '"', '\''];
-
-        let mut chunk_iter = self.0.as_ref().split_inclusive(SPECIAL_CHARS);
-        // All chunks aside from the last are guaranteed to be terminated with a special char
-        // > Differs from the iterator produced by `split` in that `split_inclusive` leaves the
-        // > matched part as the terminator of the substring.
-        let last_chunk = chunk_iter.next_back();
-        for chunk in chunk_iter {
-            fmt_special_terminated_text(f, chunk)?;
-        }
-        if let Some(chunk) = last_chunk {
-            // The last chunk might end with a special char
-            // > If the last element of the string is matched, that element will be considered the
-            // > terminator of the preceding substring. That substring will be the last item
-            // > returned by the iterator.
-            if chunk.ends_with(SPECIAL_CHARS) {
-                fmt_special_terminated_text(f, chunk)?;
-            } else {
-                f.write_str(chunk)?;
-            }
-        }
-
-        Ok(())
+        f.write_str(s)
     }
 }


### PR DESCRIPTION
Another perf speedup for escaping text similar to all of the other char -> byte changes