### PR TITLE
interpret colors overlapping in 256- and 16-color palettes as 16-color

### DIFF
--- a/crates/ansi-to-html/src/color.rs
+++ b/crates/ansi-to-html/src/color.rs
@@ -61,7 +61,15 @@ impl Color {
                     .next()
                     .transpose()?
                     .ok_or_else(Error::invalid_ansi("Missing 8-bit color"))?;
-                Color::EightBit(EightBitColor::new(color))
+                // While not described specifically by ECMA-48 or ISO 8613-6/ITU T.416,
+                // the xterm256 palette is structured so the first 16 colors are the same
+                // as the colors of the 4-bit palette. This is true of xterm's 88-color
+                // palette as well.
+                match color {
+                    0..=7 => Color::parse_4bit(color)?,
+                    8..=15 => Color::parse_4bit_bright(color - 8)?,
+                    _ => Color::EightBit(EightBitColor::new(color)),
+                }
             }
             2 => {
                 let r = iter.next().transpose()?;

--- a/crates/ansi-to-html/tests/ansi_to_html.rs
+++ b/crates/ansi-to-html/tests/ansi_to_html.rs
@@ -29,7 +29,7 @@ fn human_readable_to_ansi(s: &str) -> String {
                 "red" => out.push_str("31"),
                 "green" => out.push_str("32"),
                 // 8-bit foreground colors
-                "8_240" | "8_246" | "8_249" => {
+                code if code.starts_with("8_") => {
                     let num = inner.strip_prefix("8_").unwrap();
                     out.push_str("38;5;");
                     out.push_str(num);
@@ -122,6 +122,52 @@ fn underlines() {
         no_opt,
         @"<u>Single</u> <u style='text-decoration-style:double'>Double</u>"
     );
+}
+
+#[test]
+fn ansi_8bit_specification_of_4bit_color() {
+    let readable = r#"
+The first sixteen colors in the 8-bit palette are de facto standardized as the old 4-bit palette:
+{{ 8_0 }}black{{ res }}
+{{ 8_1 }}red{{ res }}
+{{ 8_2 }}green{{ res }}
+{{ 8_3 }}yellow{{ res }}
+{{ 8_4 }}blue{{ res }}
+{{ 8_5 }}magenta{{ res }}
+{{ 8_6 }}cyan{{ res }}
+{{ 8_7 }}white{{ res }}
+Where the bright colors, too, are bright in the overlap of the 8-bit and 4-bit palettes:
+{{ 8_8 }}bright black{{ res }}
+{{ 8_9 }}bright red{{ res }}
+{{ 8_10 }}bright green{{ res }}
+{{ 8_11 }}bright yellow{{ res }}
+{{ 8_12 }}bright blue{{ res }}
+{{ 8_13 }}bright magenta{{ res }}
+{{ 8_14 }}bright cyan{{ res }}
+{{ 8_15 }}bright white{{ res }}
+    "#;
+
+    let converted = human_readable_to_html(readable.trim());
+    insta::assert_snapshot!(converted, @r"
+    The first sixteen colors in the 8-bit palette are de facto standardized as the old 4-bit palette:
+    <span style='color:var(--black,#000)'>black</span>
+    <span style='color:var(--red,#a00)'>red</span>
+    <span style='color:var(--green,#0a0)'>green</span>
+    <span style='color:var(--yellow,#a60)'>yellow</span>
+    <span style='color:var(--blue,#00a)'>blue</span>
+    <span style='color:var(--magenta,#a0a)'>magenta</span>
+    <span style='color:var(--cyan,#0aa)'>cyan</span>
+    <span style='color:var(--white,#aaa)'>white</span>
+    Where the bright colors, too, are bright in the overlap of the 8-bit and 4-bit palettes:
+    <span style='color:var(--bright-black,#555)'>bright black</span>
+    <span style='color:var(--bright-red,#f55)'>bright red</span>
+    <span style='color:var(--bright-green,#5f5)'>bright green</span>
+    <span style='color:var(--bright-yellow,#ff5)'>bright yellow</span>
+    <span style='color:var(--bright-blue,#55f)'>bright blue</span>
+    <span style='color:var(--bright-magenta,#f5f)'>bright magenta</span>
+    <span style='color:var(--bright-cyan,#5ff)'>bright cyan</span>
+    <span style='color:var(--bright-white,#fff)'>bright white</span>
+    ");
 }
 
 #[test]


### PR DESCRIPTION
i was going to open an issue, but figure the patch is tiny so i'd start here :) a friend was running text produced by `crossterm` through `ansi-to-html` and the output wasn't really stylable, even though they were only using the 16-color styles from `crossterm`.

another reasonable way to get this behavior might be a setting on [`Converter`](https://docs.rs/ansi-to-html/latest/ansi_to_html/struct.Converter.html) but the intersection of a new `low_8bit_as_4bit_color` and `four_bit_var_prefix` feels like it wouldn't be great to describe.

i'm loath to cite Wikipedia, but the [256-color table there](https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit) is in line with what i'd expect from [`xterm-256color`](https://github.com/Distrotech/ncurses/blob/master/test/xterm-256color.dat). on the whole it seems pretty unlikely someone would _want_ these colors to not be styled with the same CSS variables as for 4-bit color, so i think it's unlikey someone *wouldn't* want the behavior described in the new test, regardless of implementation.

a better approach here might be to have `into_color_css` have an arm for `Color::EightBitColor`... on second look that's more in line with `impl fmt::Display for Color` anyway. happy to change this to that approach if you want.

---

in practice the first 16 colors of the palette selected by `CSI {3,4}8;5<N>m` are identical to the 16-color palette used for `CSI {3,7}[0-7]`. at least some programs and libraries opt to emit only `38;5;<N>m` on the (IMO reasonable) expectation that whatever is processing the text will support those escape codes. unfortunately, this means the nice `color:var(--cyan,#0aa)` and such for the 16-color palette does not currently apply for theoretically-identical colors.

`crossterm` is one such library that [chooses
expediency](https://github.com/crossterm-rs/crossterm/blob/fc8f977/src/style/types/colored.rs#L131-L151) here, leading to the funny outcome that Rust programs are particularly likely to produce output that is more difficult to style.

i have to admit i was hoping to find a nice standard to cite here, but there doesn't seem to be one. the equivalence between the first 16 colors of the 256 indexed-color space seems to be defined only by xterm - EMCA-48 delegates color palette definition to ITU T.416, and T.416 doesn't seem to say much of detail about the palette other than that it's "indexed-color".