### PR TITLE
chore: Remove invalid dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    labels:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
-    labels:


### PR DESCRIPTION
Looks like the missing `labels:` value is making dependabot angry

![image](https://github.com/user-attachments/assets/3795aa91-3b4e-479d-8843-2d310ee964e6)

Removing it should have the same intended effect