### PR TITLE
Support Windows via `pwsh` - Powershell needs to be installed manually

### DIFF
--- a/crates/fake-tty/src/lib.rs
+++ b/crates/fake-tty/src/lib.rs
@@ -6,7 +6,11 @@
 //! ## Example
 //!
 //! ```
-//! let output = fake_tty::bash_command("ls").unwrap()
+//! #[cfg(not(target_os = "windows"))]
+//! let cmd = fake_tty::bash_command("ls");
+//! #[cfg(target_os = "windows")]
+//! let cmd = fake_tty::command("ls", None);
+//! let output = cmd.unwrap()
 //!     .output().unwrap();
 //! assert!(output.status.success());
 //!
@@ -54,7 +58,11 @@ pub fn command(command: &str, shell: Option<&str>) -> io::Result<Command> {
 /// use std::process::{Command, Stdio};
 /// use fake_tty::make_script_command;
 ///
-/// let output = make_script_command("ls", Some("bash")).unwrap()
+/// #[cfg(not(target_os = "windows"))]
+/// let shell = Some("bash");
+/// #[cfg(target_os = "windows")]
+/// let shell = None;
+/// let output = make_script_command("ls", shell).unwrap()
 ///     .stdout(Stdio::piped())
 ///     .stderr(Stdio::piped())
 ///     .output().unwrap();
@@ -62,7 +70,14 @@ pub fn command(command: &str, shell: Option<&str>) -> io::Result<Command> {
 /// assert!(output.status.success());
 /// ```
 pub fn make_script_command(c: &str, shell: Option<&str>) -> io::Result<Command> {
-    let shell = which_shell(shell.unwrap_or("bash"))?;
+    let shell = {
+        #[cfg(not(target_os = "windows"))]
+        let shell_default = shell.unwrap_or("bash");
+        #[cfg(target_os = "windows")]
+        let shell_default = shell.unwrap_or("pwsh");
+
+        which_shell(shell_default)?
+    };
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
@@ -80,11 +95,19 @@ pub fn make_script_command(c: &str, shell: Option<&str>) -> io::Result<Command> 
         Ok(command)
     }
 
+    #[cfg(target_os = "windows")]
+    {
+        let mut command = Command::new(shell.trim());
+        command.args(&["-Command", c]);
+        Ok(command)
+    }
+
     #[cfg(not(any(
         target_os = "android",
         target_os = "linux",
         target_os = "macos",
-        target_os = "freebsd"
+        target_os = "freebsd",
+        target_os = "windows"
     )))]
     compile_error!("This platform is not supported. See https://github.com/Aloso/to-html/issues/3")
 }
@@ -106,28 +129,59 @@ pub fn get_stdout(stdout: Vec<u8>) -> Result<String, FromUtf8Error> {
         }
         Ok(out)
     }
+
+    #[cfg(target_os = "windows")]
+    {
+        Ok(out)
+    }
 }
 
 fn which_shell(shell: &str) -> io::Result<String> {
-    let which = Command::new("which")
-        .arg(shell)
-        .stdout(Stdio::piped())
-        .output()?;
+    #[cfg(not(target_os = "windows"))]
+    {
+        let which = Command::new("which")
+            .arg(shell)
+            .stdout(Stdio::piped())
+            .output()?;
 
-    if which.status.success() {
-        Ok(String::from_utf8(which.stdout).unwrap())
-    } else {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            String::from_utf8(which.stderr).unwrap(),
-        ))
+        if which.status.success() {
+            Ok(String::from_utf8(which.stdout).unwrap())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                String::from_utf8(which.stderr).unwrap(),
+            ))
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let get_command = Command::new("pwsh")
+            .args(&["-Command", &format!("(Get-Command {shell}).Path")])
+            .stdout(Stdio::piped())
+            .output()?;
+
+        // pwsh returns 0 when the subcommand fails, so we can't just
+        // use `get_command.status.succes()`
+        let output = String::from_utf8(get_command.stdout).unwrap();
+        if !output.trim().is_empty() {
+            Ok(output)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                String::from_utf8(get_command.stderr).unwrap(),
+            ))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     fn run(s: &str) -> String {
+        #[cfg(not(target_os = "windows"))]
         let output = crate::bash_command(s).unwrap().output().unwrap();
+        #[cfg(target_os = "windows")]
+        let output = crate::command(s, None).unwrap().output().unwrap();
         let s1 = crate::get_stdout(output.stdout).unwrap();
 
         if crate::which_shell("zsh").is_ok() {
@@ -140,26 +194,60 @@ mod tests {
         s1
     }
 
-    #[test]
-    fn echo() {
-        assert_eq!(run("echo hello world"), "hello world\n");
+    #[cfg(not(target_os = "windows"))]
+    mod not_windows {
+        use super::run;
+
+        #[test]
+        fn echo() {
+            assert_eq!(run("echo hello world"), "hello world\n");
+        }
+
+        #[test]
+        fn seq() {
+            assert_eq!(run("seq 3"), "1\n2\n3\n");
+        }
+
+        #[test]
+        fn echo_quotes() {
+            assert_eq!(run(r#"echo "Hello \$\`' world!""#), "Hello $`' world!\n");
+        }
+
+        #[test]
+        fn echo_and_cat() {
+            assert_eq!(
+                run("echo 'look, bash support!' | cat"),
+                "look, bash support!\n"
+            );
+        }
     }
 
-    #[test]
-    fn seq() {
-        assert_eq!(run("seq 3"), "1\n2\n3\n");
-    }
+    #[cfg(target_os = "windows")]
+    mod windows {
+        use super::run;
 
-    #[test]
-    fn echo_quotes() {
-        assert_eq!(run(r#"echo "Hello \$\`' world!""#), "Hello $`' world!\n");
-    }
+        #[test]
+        fn echo() {
+            assert_eq!(run("echo hello world"), "hello\r\nworld\r\n");
+        }
 
-    #[test]
-    fn echo_and_cat() {
-        assert_eq!(
-            run("echo 'look, bash support!' | cat"),
-            "look, bash support!\n"
-        );
+        #[test]
+        fn seq() {
+            assert_eq!(run("1..3"), "1\r\n2\r\n3\r\n");
+        }
+
+        #[test]
+        fn echo_quotes() {
+            // In powershell, backtick is used to escape the next character.
+            assert_eq!(run(r#"echo "Hello `$``' world!""#), "Hello $`' world!\r\n");
+        }
+
+        #[test]
+        fn echo_and_pipe() {
+            assert_eq!(
+                run("echo 'look, pipe support!' | % { Write-Host $_ }"),
+                "look, pipe support!\r\n"
+            );
+        }
     }
 }


### PR DESCRIPTION
* Part of #3.

If we use the `Powershell` binary, it defaults to Powershell 1.0, which doesn't have ANSI support; I think it only got introduced in Powershell 5.0.

After installing powershell manually, `pwsh` is available on the `PATH`.

I know some windows users will have git-bash installed, but I don't, so as a first cut I just added support for `pwsh`.

I added tests for windows; and I changed the current working directory restoration to not use `pwd`, so it would be good to test on a non-windows system with a command that changes the working dir.