### PR TITLE
refactor: Speed up the ansi parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ dependencies = [
  "divan",
  "flate2",
  "insta",
+ "memchr",
  "regex",
 ]
 

--- a/crates/ansi-to-html/Cargo.toml
+++ b/crates/ansi-to-html/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 keywords = ["color", "cli", "terminal", "html"]
 
 [dependencies]
+memchr = "2.7.4"
 regex = "1.7.3"
 
 [features]

--- a/crates/ansi-to-html/src/ansi/parse.rs
+++ b/crates/ansi-to-html/src/ansi/parse.rs
@@ -1,30 +1,28 @@
-use std::str::CharIndices;
-
-const ESCAPE: char = '\u{1b}';
+const ESCAPE: u8 = 0x1b;
 
 #[must_use]
 pub(crate) struct AnsiParser<'text> {
     text: &'text str,
-    chars: CharIndices<'text>,
-    /// Potentially stores the character that broke us out of the last `.next()` call
-    ///
-    /// In the case of an invalid/unrecognized ANSI code or when iterating over plain text portions
-    /// the character that breaks us out of the current token that we're parsing (e.g. when we see
-    /// an escape while parsing plain text) will be stored in this field and taken into account on
-    /// the start of the next iteration. This removes the need to peek each character to avoid
-    /// advancing the iterator by retaining the character for next iteration instead
-    ended_last_iter_on: Option<char>,
+    index: usize,
 }
 
 impl<'text> AnsiParser<'text> {
     pub(crate) fn new(text: &'text str) -> Self {
-        let chars = text.char_indices();
-        let ended_last_iter_on = None;
-        Self {
-            text,
-            chars,
-            ended_last_iter_on,
-        }
+        let index = 0;
+        Self { text, index }
+    }
+
+    fn current_byte(&self) -> Option<u8> {
+        self.text.as_bytes().get(self.index).copied()
+    }
+
+    fn next_byte(&mut self) -> Option<u8> {
+        self.inc();
+        self.current_byte()
+    }
+
+    fn inc(&mut self) {
+        self.index += 1;
     }
 }
 
@@ -38,52 +36,41 @@ impl<'text> Iterator for AnsiParser<'text> {
     type Item = AnsiFragment<'text>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let ended_last_iter_on = self.ended_last_iter_on.take();
-        let start_idx = self.chars.offset() - ended_last_iter_on.map(char::len_utf8).unwrap_or(0);
-        let c = ended_last_iter_on.or_else(|| self.chars.next().map(|(_, c)| c))?;
+        let start_idx = self.index;
         // All ANSI codes start with ESCAPE, so check if we're parsing an ANSI code or plain text
         // with this iteration
-        if c == ESCAPE {
+        if self.current_byte()? == ESCAPE {
             let mut state = State::default();
             loop {
-                let Some((_, c)) = self.chars.next() else {
-                    break Some(AnsiFragment::Text(
-                        &self.text[start_idx..self.chars.offset()],
-                    ));
+                let Some(b) = self.next_byte() else {
+                    break Some(AnsiFragment::Text(&self.text[start_idx..self.index]));
                 };
 
-                state.munch(c);
+                state.munch(b);
                 match state.into() {
                     Status::InSequence => {}
                     Status::Accept => {
-                        break Some(AnsiFragment::Sequence(
-                            &self.text[start_idx..self.chars.offset()],
-                        ));
+                        self.inc();
+                        break Some(AnsiFragment::Sequence(&self.text[start_idx..self.index]));
                     }
                     // NOTE(cosmic): niche case, but behavior is diverging from the regex here
                     // which would return invalid ansi codes _along with_ any surround text whereas
                     // we're emitting them separately atm
                     Status::RejectAsText => {
-                        self.ended_last_iter_on = Some(c);
                         // Fortunately the starting ESC of an ANSI sequence can't appear within
                         // the sequence itself, so we don't need to worry about any backtracking or
                         // reparsing
-                        break Some(AnsiFragment::Text(
-                            &self.text[start_idx..self.chars.offset() - c.len_utf8()],
-                        ));
+                        break Some(AnsiFragment::Text(&self.text[start_idx..self.index]));
                     }
                 }
             }
         } else {
-            while let Some((_, c)) = self.chars.next() {
-                if c == ESCAPE {
-                    self.ended_last_iter_on = Some(c);
+            while let Some(b) = self.next_byte() {
+                if b == ESCAPE {
                     break;
                 }
             }
-            let end_offset = self.ended_last_iter_on.map(char::len_utf8).unwrap_or(0);
-            let end_idx = self.chars.offset() - end_offset;
-            Some(AnsiFragment::Text(&self.text[start_idx..end_idx]))
+            Some(AnsiFragment::Text(&self.text[start_idx..self.index]))
         }
     }
 }
@@ -102,18 +89,25 @@ enum State {
 }
 
 impl State {
-    fn munch(&mut self, c: char) {
-        *self = match (*self, c) {
+    fn munch(&mut self, b: u8) {
+        *self = match (*self, b) {
             // Weird `<ESC>(B` ansi code
-            (Self::Escape, '(') => Self::EscapeOpenParen,
-            (Self::EscapeOpenParen, 'B') => Self::Accept,
+            (Self::Escape, b'(') => Self::EscapeOpenParen,
+            (Self::EscapeOpenParen, b'B') => Self::Accept,
             // CSI-related codes
-            (Self::Escape, '[') => Self::Csi,
-            (Self::Csi | Self::Digit | Self::SemiColon, '0'..='9') => Self::Digit,
-            (Self::Digit, ';') => Self::SemiColon,
+            (Self::Escape, b'[') => Self::Csi,
+            (Self::Csi | Self::Digit | Self::SemiColon, b'0'..=b'9') => Self::Digit,
+            (Self::Digit, b';') => Self::SemiColon,
             (
                 Self::Csi | Self::Digit | Self::SemiColon,
-                'A'..='H' | 'J' | 'K' | 'S' | 'T' | 'f' | 'h' | 'i' | 'l' | 'm' | 'n' | 's' | 'u',
+                b'A'..=b'H'
+                | b'J'..=b'K'
+                | b'S'..=b'T'
+                | b'f'
+                | b'h'..=b'i'
+                | b'l'..=b'n'
+                | b's'
+                | b'u',
             ) => Self::Accept,
             // Anything else is invalid
             _ => Self::Trap,

--- a/crates/ansi-to-html/src/ansi/parse.rs
+++ b/crates/ansi-to-html/src/ansi/parse.rs
@@ -1,4 +1,4 @@
-use std::{mem, ops::Range, str::CharIndices};
+use std::str::CharIndices;
 
 const ESCAPE: char = '\u{1b}';
 
@@ -6,51 +6,24 @@ const ESCAPE: char = '\u{1b}';
 pub(crate) struct AnsiParser<'text> {
     text: &'text str,
     chars: CharIndices<'text>,
-    /// Stores whether the last iteration of `.next()` ended on an escape character
+    /// Potentially stores the character that broke us out of the last `.next()` call
     ///
-    /// The parser sifts through text to find ANSI codes which **always** start with an escape
-    /// character. We can exploit this to speed up the hot path of iterating over plain text by
-    /// unconditionally iterating over characters and storing whether the character that broke us
-    /// out was an escape in this field. This avoids the need to peek each character to see if it's
-    /// the start of an ANSI code by re-framing the ansi code parsing to start _after_ the intial
-    /// escape and adjusting the starting index to still include it
-    was_on_esc: bool,
+    /// In the case of an invalid/unrecognized ANSI code or when iterating over plain text portions
+    /// the character that breaks us out of the current token that we're parsing (e.g. when we see
+    /// an escape while parsing plain text) will be stored in this field and taken into account on
+    /// the start of the next iteration. This removes the need to peek each character to avoid
+    /// advancing the iterator by retaining the character for next iteration instead
+    ended_last_iter_on: Option<char>,
 }
 
 impl<'text> AnsiParser<'text> {
     pub(crate) fn new(text: &'text str) -> Self {
         let chars = text.char_indices();
-        let was_on_esc = false;
+        let ended_last_iter_on = None;
         Self {
             text,
             chars,
-            was_on_esc,
-        }
-    }
-
-    fn parse_ansi_code_after_esc(&mut self) -> Option<AnsiFragment<'text>> {
-        let mut fsm = AnsiFsm::new(&mut self.chars);
-        loop {
-            let Some(status) = fsm.peek() else {
-                break Some(AnsiFragment::Text(&self.text[fsm.span()]));
-            };
-
-            match status {
-                Status::InSequence => _ = fsm.next(),
-                Status::Accept => {
-                    fsm.next();
-                    break Some(AnsiFragment::Sequence(&self.text[fsm.span()]));
-                }
-                // NOTE(cosmic): niche case, but behavior is diverging from the regex here
-                // which would return invalid ansi codes _along with_ any surround text whereas
-                // we're emitting them separately atm
-                Status::RejectAsText => {
-                    // Fortunately the starting ESC of an ANSI sequence can't appear within
-                    // the sequence itself, so we don't need to worry about any backtracking or
-                    // reparsing
-                    break Some(AnsiFragment::Text(&self.text[fsm.span()]));
-                }
-            }
+            ended_last_iter_on,
         }
     }
 }
@@ -65,65 +38,53 @@ impl<'text> Iterator for AnsiParser<'text> {
     type Item = AnsiFragment<'text>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if mem::take(&mut self.was_on_esc) {
-            self.parse_ansi_code_after_esc()
-        } else {
-            let start_idx = self.chars.offset();
-            let (_, c) = self.chars.next()?;
-            if c == ESCAPE {
-                return self.parse_ansi_code_after_esc();
+        let ended_last_iter_on = self.ended_last_iter_on.take();
+        let start_idx = self.chars.offset() - ended_last_iter_on.map(char::len_utf8).unwrap_or(0);
+        let c = ended_last_iter_on.or_else(|| self.chars.next().map(|(_, c)| c))?;
+        // All ANSI codes start with ESCAPE, so check if we're parsing an ANSI code or plain text
+        // with this iteration
+        if c == ESCAPE {
+            let mut state = State::default();
+            loop {
+                let Some((_, c)) = self.chars.next() else {
+                    break Some(AnsiFragment::Text(
+                        &self.text[start_idx..self.chars.offset()],
+                    ));
+                };
+
+                state.munch(c);
+                match state.into() {
+                    Status::InSequence => {}
+                    Status::Accept => {
+                        break Some(AnsiFragment::Sequence(
+                            &self.text[start_idx..self.chars.offset()],
+                        ));
+                    }
+                    // NOTE(cosmic): niche case, but behavior is diverging from the regex here
+                    // which would return invalid ansi codes _along with_ any surround text whereas
+                    // we're emitting them separately atm
+                    Status::RejectAsText => {
+                        self.ended_last_iter_on = Some(c);
+                        // Fortunately the starting ESC of an ANSI sequence can't appear within
+                        // the sequence itself, so we don't need to worry about any backtracking or
+                        // reparsing
+                        break Some(AnsiFragment::Text(
+                            &self.text[start_idx..self.chars.offset() - c.len_utf8()],
+                        ));
+                    }
+                }
             }
+        } else {
             while let Some((_, c)) = self.chars.next() {
                 if c == ESCAPE {
-                    self.was_on_esc = true;
+                    self.ended_last_iter_on = Some(c);
                     break;
                 }
             }
-            let end_offset = if self.was_on_esc {
-                ESCAPE.len_utf8()
-            } else {
-                0
-            };
+            let end_offset = self.ended_last_iter_on.map(char::len_utf8).unwrap_or(0);
             let end_idx = self.chars.offset() - end_offset;
             Some(AnsiFragment::Text(&self.text[start_idx..end_idx]))
         }
-    }
-}
-
-/// A small finite state machine that parses ANSI codes after the initial ESC
-struct AnsiFsm<'short, 'text: 'short> {
-    chars: &'short mut CharIndices<'text>,
-    state: State,
-    start_idx: usize,
-}
-
-impl<'short, 'text> AnsiFsm<'short, 'text> {
-    fn new(chars: &'short mut CharIndices<'text>) -> Self {
-        let state = State::default();
-        let start_idx = chars.offset() - ESCAPE.len_utf8();
-        Self {
-            chars,
-            state,
-            start_idx,
-        }
-    }
-
-    fn peek(&self) -> Option<Status> {
-        let mut chars_lookahead = self.chars.to_owned();
-        let mut state_lookahead = self.state.to_owned();
-        let (_, c) = chars_lookahead.next()?;
-        state_lookahead.munch(c);
-        Some(state_lookahead.into())
-    }
-
-    fn next(&mut self) -> Option<Status> {
-        let (_, c) = self.chars.next()?;
-        self.state.munch(c);
-        Some(self.state.into())
-    }
-
-    fn span(self) -> Range<usize> {
-        self.start_idx..self.chars.offset()
     }
 }
 

--- a/crates/ansi-to-html/src/ansi/parse.rs
+++ b/crates/ansi-to-html/src/ansi/parse.rs
@@ -65,11 +65,13 @@ impl<'text> Iterator for AnsiParser<'text> {
                 }
             }
         } else {
-            while let Some(b) = self.next_byte() {
-                if b == ESCAPE {
-                    break;
-                }
-            }
+            // Increment past the byte we just checked
+            self.inc();
+            // Find the next ESCAPE if there is one and adjust our index accordingly
+            match memchr::memchr(ESCAPE, &self.text.as_bytes()[start_idx..]) {
+                Some(end_offset) => self.index += end_offset - 1,
+                None => self.index = self.text.len(),
+            };
             Some(AnsiFragment::Text(&self.text[start_idx..self.index]))
         }
     }

--- a/crates/ansi-to-html/src/ansi/parse.rs
+++ b/crates/ansi-to-html/src/ansi/parse.rs
@@ -1,15 +1,57 @@
-use std::{ops::Range, str::CharIndices};
+use std::{mem, ops::Range, str::CharIndices};
+
+const ESCAPE: char = '\u{1b}';
 
 #[must_use]
 pub(crate) struct AnsiParser<'text> {
     text: &'text str,
     chars: CharIndices<'text>,
+    /// Stores whether the last iteration of `.next()` ended on an escape character
+    ///
+    /// The parser sifts through text to find ANSI codes which **always** start with an escape
+    /// character. We can exploit this to speed up the hot path of iterating over plain text by
+    /// unconditionally iterating over characters and storing whether the character that broke us
+    /// out was an escape in this field. This avoids the need to peek each character to see if it's
+    /// the start of an ANSI code by re-framing the ansi code parsing to start _after_ the intial
+    /// escape and adjusting the starting index to still include it
+    was_on_esc: bool,
 }
 
 impl<'text> AnsiParser<'text> {
     pub(crate) fn new(text: &'text str) -> Self {
         let chars = text.char_indices();
-        Self { text, chars }
+        let was_on_esc = false;
+        Self {
+            text,
+            chars,
+            was_on_esc,
+        }
+    }
+
+    fn parse_ansi_code_after_esc(&mut self) -> Option<AnsiFragment<'text>> {
+        let mut fsm = AnsiFsm::new(&mut self.chars);
+        loop {
+            let Some(status) = fsm.peek() else {
+                break Some(AnsiFragment::Text(&self.text[fsm.span()]));
+            };
+
+            match status {
+                Status::InSequence => _ = fsm.next(),
+                Status::Accept => {
+                    fsm.next();
+                    break Some(AnsiFragment::Sequence(&self.text[fsm.span()]));
+                }
+                // NOTE(cosmic): niche case, but behavior is diverging from the regex here
+                // which would return invalid ansi codes _along with_ any surround text whereas
+                // we're emitting them separately atm
+                Status::RejectAsText => {
+                    // Fortunately the starting ESC of an ANSI sequence can't appear within
+                    // the sequence itself, so we don't need to worry about any backtracking or
+                    // reparsing
+                    break Some(AnsiFragment::Text(&self.text[fsm.span()]));
+                }
+            }
+        }
     }
 }
 
@@ -23,61 +65,47 @@ impl<'text> Iterator for AnsiParser<'text> {
     type Item = AnsiFragment<'text>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut dfa = Dfa::new(&mut self.chars).unwrap();
-
-        match dfa.next()? {
-            // Walk through the current run of text
-            Status::Waiting => {
-                while dfa.peek() == Some(Status::Waiting) {
-                    dfa.next();
-                }
-                Some(AnsiFragment::Text(&self.text[dfa.span()]))
+        if mem::take(&mut self.was_on_esc) {
+            self.parse_ansi_code_after_esc()
+        } else {
+            let start_idx = self.chars.offset();
+            let (_, c) = self.chars.next()?;
+            if c == ESCAPE {
+                return self.parse_ansi_code_after_esc();
             }
-            // Walk through the ansi sequence
-            Status::InSequence => loop {
-                let Some(status) = dfa.peek() else {
-                    break Some(AnsiFragment::Text(&self.text[dfa.span()]));
-                };
-
-                match status {
-                    Status::Waiting => unreachable!("We're already past `Waiting`"),
-                    Status::InSequence => _ = dfa.next(),
-                    Status::Accept => {
-                        dfa.next();
-                        break Some(AnsiFragment::Sequence(&self.text[dfa.span()]));
-                    }
-                    // TODO(cosmic): niche case, but behavior is diverging from the regex here
-                    // which would return invalid ansi codes _along with_ any surround text whereas
-                    // we're emitting them separately atm
-                    Status::RejectAsText => {
-                        // Fortunately the starting ESC of an ANSI sequence can't appear within
-                        // the sequence itself, so we don't need to worry about any backtracking or
-                        // reparsing
-                        break Some(AnsiFragment::Text(&self.text[dfa.span()]));
-                    }
+            while let Some((_, c)) = self.chars.next() {
+                if c == ESCAPE {
+                    self.was_on_esc = true;
+                    break;
                 }
-            },
-            _ => unreachable!("No other possible statuses after just one char"),
+            }
+            let end_offset = if self.was_on_esc {
+                ESCAPE.len_utf8()
+            } else {
+                0
+            };
+            let end_idx = self.chars.offset() - end_offset;
+            Some(AnsiFragment::Text(&self.text[start_idx..end_idx]))
         }
     }
 }
 
-/// A small DFA that detects and emits ANSI codes from an underlying `CharIndices`
-struct Dfa<'short, 'text: 'short> {
+/// A small finite state machine that parses ANSI codes after the initial ESC
+struct AnsiFsm<'short, 'text: 'short> {
     chars: &'short mut CharIndices<'text>,
     state: State,
     start_idx: usize,
 }
 
-impl<'short, 'text> Dfa<'short, 'text> {
-    fn new(chars: &'short mut CharIndices<'text>) -> Option<Self> {
+impl<'short, 'text> AnsiFsm<'short, 'text> {
+    fn new(chars: &'short mut CharIndices<'text>) -> Self {
         let state = State::default();
-        let start_idx = chars.offset();
-        Some(Self {
+        let start_idx = chars.offset() - ESCAPE.len_utf8();
+        Self {
             chars,
             state,
             start_idx,
-        })
+        }
     }
 
     fn peek(&self) -> Option<Status> {
@@ -101,12 +129,10 @@ impl<'short, 'text> Dfa<'short, 'text> {
 
 #[derive(Clone, Copy, Default)]
 enum State {
-    /// Waiting to see an escape
     #[default]
-    Init,
+    Escape,
     Trap,
     Accept,
-    Escape,
     EscapeOpenParen,
     /// Control Sequence Introducer (CSI) - Indicates the start of an ansi sequence
     Csi,
@@ -117,9 +143,6 @@ enum State {
 impl State {
     fn munch(&mut self, c: char) {
         *self = match (*self, c) {
-            // Waiting for ESC
-            (Self::Init, '\u{1b}') => Self::Escape,
-            (Self::Init, _) => Self::Init,
             // Weird `<ESC>(B` ansi code
             (Self::Escape, '(') => Self::EscapeOpenParen,
             (Self::EscapeOpenParen, 'B') => Self::Accept,
@@ -139,7 +162,6 @@ impl State {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Status {
-    Waiting,
     InSequence,
     Accept,
     RejectAsText,
@@ -148,7 +170,6 @@ enum Status {
 impl From<State> for Status {
     fn from(state: State) -> Self {
         match state {
-            State::Init => Self::Waiting,
             State::Trap => Self::RejectAsText,
             State::Accept => Self::Accept,
             State::Escape
@@ -163,6 +184,19 @@ impl From<State> for Status {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn plain() {
+        let parser = AnsiParser::new("Hello World!");
+        let fragments: Vec<_> = parser.into_iter().collect();
+        insta::assert_debug_snapshot!(fragments, @r#"
+        [
+            Text(
+                "Hello World!",
+            ),
+        ]
+        "#);
+    }
 
     #[test]
     fn variety() {


### PR DESCRIPTION
Changes the parser to work over bytes instead of chars (same motivation as #63) and avoids peeking by no longer unconditionally incrementing the iterator while parsing

Unconditionally pulls in `memchr` for finding the initial escape byte that starts ansi sequences to match the speed of the original regex-based parser (33 GB/s with no escape and no opt!!!!) when parsing plain text (aka when there is no escape byte to be found)

Probably best to _not_ review commit-by-commit because the final diff is so simple