### PR TITLE
feat: support parsing OSC sequences

### DIFF
--- a/crates/ansi-to-html/tests/ansi_to_html.rs
+++ b/crates/ansi-to-html/tests/ansi_to_html.rs
@@ -226,3 +226,16 @@ fn overline() {
         @"<u style='text-decoration:overline'>over <u>and under</u> just over</u> plain"
     );
 }
+
+#[test]
+fn hyperlink() {
+    let input = "Finished \
+        \x1b]8;;https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles\
+        \x1b\\`dev` profile [unoptimized + debuginfo]\x1b]8;;\x1b\\ \
+        target(s) in 0.04s";
+    let converted = ansi_to_html::convert(input).unwrap();
+    insta::assert_snapshot!(
+        converted,
+        @"Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s"
+    );
+}


### PR DESCRIPTION
Resolves #56 

Adds support for parsing Operating System Command (OSC) sequences. These sequences are started with an ESCAPE followed by `]` and end on a string terminator which consists of either the lone BELL character or ESCAPE followed by a `\`

Currently these sequences are totally stripped from the output because they always go into the following branch in `fn ansi_to_html()`

```rust
if !ansi_codes.ends_with('m') {
    continue;
}
```

This is from OSC sequences always ending with a string terminator which never end on `m`. Adding support for hyperlinks (#55) will take a little bit of extra logic to handle interpretting OSC codes, but nothing too major :crossed_fingers: (jk it'll definitely be complicated)