### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         channel: [stable, beta]
     steps:
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.channel }}
-          components: clippy, rustfmt
+      - name: Install ${{ matrix.channel }} toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal --component clippy,rustfmt
+          rustup default ${{ matrix.rust }}
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run `cargo fmt`
@@ -37,9 +37,10 @@ jobs:
         channel: [stable, beta]
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.channel }}
+      - name: Install ${{ matrix.channel }} toolchain
+        run: |
+          rustup toolchain install ${{ matrix.rust }} --profile minimal
+          rustup default ${{ matrix.rust }}
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build and run tests
@@ -50,7 +51,10 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: dtolnay/rust-toolchain@nightly
+      - name: Install nightly toolchain
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup default nightly
       - name: Checkout
         uses: actions/checkout@v4
       # Run the fuzzer for a minute

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           cargo fmt --all -- --check
       - name: Run `cargo clippy`
         run: |
-          cargo clippy
+          cargo clippy -- -D warnings
 
   test:
     needs: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Build and run tests
         run: |
           cargo test --workspace
+          cargo bench -p ansi-to-html --profile dev -- --test
 
   fuzz:
     needs: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,13 +53,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - name: Checkout
         uses: actions/checkout@v4
-        
-      - name: Cache fuzz corpus
-        uses: actions/cache@v4
-        with:
-          key: ${{ runner.os }}-${{ hashFiles('Cargo.lock', 'crates/ansi-to-html/fuzz/fuzz_targets/**') }}
-          path: crates/ansi-to-html/fuzz/corpus
-        # Run the fuzzer for a minute
+      # Run the fuzzer for a minute
       - name: Run fuzzers
         run: |
           cargo --locked install cargo-fuzz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build and run tests
         run: |
-          cargo test --verbose --workspace
+          cargo test --workspace
 
   fuzz:
     needs: lint

--- a/crates/fake-tty/src/lib.rs
+++ b/crates/fake-tty/src/lib.rs
@@ -117,10 +117,7 @@ fn which_shell(shell: &str) -> io::Result<String> {
     if which.status.success() {
         Ok(String::from_utf8(which.stdout).unwrap())
     } else {
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            String::from_utf8(which.stderr).unwrap(),
-        ))
+        Err(io::Error::other(String::from_utf8(which.stderr).unwrap()))
     }
 }
 


### PR DESCRIPTION
A handful of little tweaks

- ad78fe268e54b789368f99ca6153843c579ecd43 removes the `--verbose` flag which should make the build output significantly less verbose
- beb86f138f43684bbb53b91e061eacd1be5a5dcf removed the cache used for the fuzz corpus since the hash key for it is a pain to maintain (it's currently wrong if a change occurs in `ansi-to-html/fuzz/utils`, but `ansi-to-html/fuzz/**` would be useless since it includes the corpus that will always have different contents). Beyond that there was a minor formatting tweak
- 4d4fb4f6de846696194a937f0bc35dd320dfdab7 replaced the usage of the `dtolnay/rust-toolchain` action with directly using `rustup` because it's roughly just as simple without relying on a third-party action. We don't use any of the fancy relative release logic (e.g. stable minus 3 releases) which is the main benefit
- 71d37d4106daf359e98e5dec6db8f91a322db5e8 tests the benchmarks in CI which should help proactively catch any breakage
- 98058404fed62dd039e6bd45f2e6592776cf1012 denies clippy warnings in CI and fixes the long clippy warning that appeared in `fake-tty`