### PR TITLE
refactor: depend on `serde` and `serde_derive` separately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
  "libc",
  "logos",
  "serde",
+ "serde_derive",
  "thiserror 2.0.12",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ ansi-to-html = { path = "./crates/ansi-to-html", version = "0.2.2" }
 clap = { version = "4.5.40", features = ["derive", "wrap_help"] }
 dirs-next = "2.0.0"
 logos = "0.15.0"
-serde = { version = "1.0.219", features = ["derive"] }
+serde_derive = "1.0.219"
+serde = "1.0.219"
 toml = "0.8.23"
 thiserror = "2.0.12"
 libc = "0.2"

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -1,6 +1,6 @@
 use std::{fs, io, path::PathBuf};
 
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {


### PR DESCRIPTION
A little trick that winds up helping clean build times in a lot of cases. `serde` and `serde_derive` both generally wind up in the long chain that stalls builds where `serde_derive` has a long chain of proc-macroy crates before it and `serde` has a lot of parsery crates after it. Depending on `serde` and `serde_derive` separately winds up generating the same code, but the two chains of dependencies can build separately

## a clean `cargo check` before - 22.9s

![2025-06-27_01-07](https://github.com/user-attachments/assets/5a0748c8-2e89-44d1-afb3-4da81b0bab90)

## and after - 20.9s

![image](https://github.com/user-attachments/assets/7f246931-83f8-44e5-a1ee-6e6debb22473)
