### PR TITLE
docs(ansi-to-html): Add a pipe example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
 name = "ansi-to-html"
 version = "0.2.2"
 dependencies = [
+ "clap",
  "divan",
  "flate2",
  "insta",

--- a/crates/ansi-to-html/Cargo.toml
+++ b/crates/ansi-to-html/Cargo.toml
@@ -22,6 +22,7 @@ default = []
 lazy-init = []
 
 [dev-dependencies]
+clap = { version = "4.5.46", features = ["derive"] }
 divan = "0.1.21"
 flate2 = "1.1.2"
 insta = "1.43.1"

--- a/crates/ansi-to-html/examples/ansi2html.rs
+++ b/crates/ansi-to-html/examples/ansi2html.rs
@@ -1,0 +1,39 @@
+use std::io::{self, Read};
+
+use clap::Parser;
+
+/// A small demo that converts ANSI stdin to HTML. Typical usage would be something like
+///
+/// $ echo -e 'Plain \e[1mBold' | cargo run -q --example ansi2html > output.html
+///
+/// $ firefox output.html
+#[derive(Parser, Debug)]
+#[command(about)]
+struct Args {
+    /// Skip escaping special HTML characters before conversion
+    #[arg(long)]
+    skip_escape: bool,
+    /// Skip optimized the converted HTML
+    #[arg(long)]
+    skip_optimize: bool,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Parse our CLI args
+    let Args {
+        skip_escape,
+        skip_optimize,
+    } = Args::parse();
+
+    // HTMLify our stdin
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    let htmlified = ansi_to_html::Converter::new()
+        .skip_escape(skip_escape)
+        .skip_optimize(skip_optimize)
+        .convert(&input)?;
+
+    // Wrapping the output in `<pre>` to preserve the whitespace
+    println!("<pre>\n{htmlified}</pre>");
+    Ok(())
+}


### PR DESCRIPTION
Re-up of #51

This adds a `ansi2html` example to `ansi-to-html` that simply converts ANSI input to HTML