### PR TITLE
refactor: don't escape ansi sequences

### DIFF
--- a/crates/ansi-to-html/src/html/minifier.rs
+++ b/crates/ansi-to-html/src/html/minifier.rs
@@ -89,9 +89,9 @@ impl Minifier {
         self.code_buffer.clear();
     }
 
-    pub fn push_str(&mut self, text: &str) {
+    pub fn push_str(&mut self, text: &str, escape: bool) {
         self.apply_ansi_codes();
-        self.converter.push_str(text);
+        self.converter.push_str(text, escape);
     }
 
     pub fn into_html(mut self) -> String {

--- a/crates/ansi-to-html/src/html/mod.rs
+++ b/crates/ansi-to-html/src/html/mod.rs
@@ -1,6 +1,8 @@
 use std::fmt::Write;
 
-use crate::{Ansi, AnsiFragment, AnsiIter, AnsiParser, Color, Error, Theme, color::FourBitColor};
+use crate::{
+    Ansi, AnsiFragment, AnsiIter, AnsiParser, Color, Error, Esc, Theme, color::FourBitColor,
+};
 
 mod minifier;
 
@@ -105,6 +107,7 @@ pub fn ansi_to_html(
     input: &str,
     four_bit_var_prefix: Option<String>,
     theme: Theme,
+    escape: bool,
 ) -> Result<String, Error> {
     let mut minifier = minifier::Minifier::new(four_bit_var_prefix, theme);
 
@@ -129,7 +132,7 @@ pub fn ansi_to_html(
                     minifier.push_ansi_code(ansi?);
                 }
             }
-            AnsiFragment::Text(text) => minifier.push_str(text),
+            AnsiFragment::Text(text) => minifier.push_str(text, escape),
         }
     }
 
@@ -210,8 +213,12 @@ impl AnsiConverter {
         }
     }
 
-    fn push_str(&mut self, s: &str) {
-        self.result.push_str(s);
+    fn push_str(&mut self, s: &str, escape: bool) {
+        if escape {
+            write!(self.result, "{}", Esc(s)).unwrap();
+        } else {
+            self.result.push_str(s);
+        }
     }
 
     fn result(self) -> String {

--- a/crates/ansi-to-html/src/lib.rs
+++ b/crates/ansi-to-html/src/lib.rs
@@ -186,12 +186,7 @@ impl Converter {
             theme,
         } = *self;
 
-        let html = if skip_escape {
-            html::ansi_to_html(input, four_bit_var_prefix.to_owned(), theme)?
-        } else {
-            let input = Esc(input).to_string();
-            html::ansi_to_html(&input, four_bit_var_prefix.to_owned(), theme)?
-        };
+        let html = html::ansi_to_html(input, four_bit_var_prefix.to_owned(), theme, !skip_escape)?;
 
         let html = if skip_optimize { html } else { optimize(&html) };
 


### PR DESCRIPTION
resolves #156 

this PR winds up being roughly as fast as `main` (locally i'm measuring a touch faster now). i also tried a version that monomorphizes across two different trait impls, but it wound up being slower, so i'm sticking with this